### PR TITLE
feat: add personalization placeholders in taglines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,21 @@ ln -s $(pwd) ~/.local/share/nvim/lazy/nvim-ascii-animation
 { dir = "~/Documents/Projects/nvim-ascii-animation" }
 ```
 
+### Testing with Worktrees
+
+When working in a git worktree (e.g., `nvim-anim-issue-3`), update lazy.nvim config to point to the worktree:
+
+```lua
+-- In ~/.config/nvim/lua/plugins/dashboard.lua
+dir = "~/Documents/Projects/nvim-anim-issue-3",  -- Point to worktree
+```
+
+**Important:** Restore to main project path after merging/cleanup:
+
+```lua
+dir = "~/Documents/Projects/nvim-ascii-animation",  -- Restore to main
+```
+
 ### Git Commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Cinematic text animation for Neovim dashboards. Watch your ASCII art materialize
 - **60+ built-in ASCII arts** in 3 styles: blocks, gradient, isometric
 - **Time-aware content**: morning, afternoon, evening, night, weekend themes
 - **200+ motivational taglines** that match the time of day
+- **Personalization placeholders**: `{name}`, `{project}`, `{time}`, `{date}`, `{version}`, `{plugin_count}`
 - Works with popular dashboard plugins:
   - [snacks.nvim](https://github.com/folke/snacks.nvim)
   - [alpha-nvim](https://github.com/goolord/alpha-nvim)
@@ -239,6 +240,13 @@ require("ascii-animation").setup({
     },
     weekend_override = true,      -- Use weekend content on Sat/Sun
 
+    -- Personalization placeholders
+    placeholders = {
+      name = "Developer",         -- Override auto-detected git user.name
+      -- project = "my-project",  -- Override auto-detected project name
+      -- date_format = "%B %d, %Y", -- Custom date format
+    },
+
     -- Add your own content (merged with built-in)
     custom_arts = {
       morning = {
@@ -247,6 +255,47 @@ require("ascii-animation").setup({
     },
     custom_messages = {
       morning = { "My custom message!", "Another one" },
+    },
+  },
+})
+```
+
+### Personalization Placeholders
+
+Taglines support placeholder tokens that get replaced at render time:
+
+| Placeholder | Description | Auto-detected |
+|-------------|-------------|---------------|
+| `{name}` | User's name | From `git config user.name` |
+| `{project}` | Current project/directory name | From `cwd` |
+| `{time}` | Time-based greeting | morning/afternoon/evening/night/weekend |
+| `{date}` | Current date | Formatted date |
+| `{version}` | Neovim version | e.g., `v0.10.0` |
+| `{plugin_count}` | Number of loaded plugins | From lazy.nvim/packer |
+
+#### Example Taglines with Placeholders
+
+```lua
+-- Built-in examples
+"Good {time}, {name}!"           -- "Good morning, John!"
+"Welcome back to {project}."     -- "Welcome back to my-project."
+"Neovim {version} • {plugin_count} plugins loaded."  -- "Neovim v0.10.0 • 42 plugins loaded."
+"{date} — Make it count."        -- "February 04, 2026 — Make it count."
+```
+
+#### Custom Messages with Placeholders
+
+```lua
+require("ascii-animation").setup({
+  content = {
+    placeholders = {
+      name = "Developer",  -- Override auto-detected name
+    },
+    custom_messages = {
+      morning = {
+        "Rise and shine, {name}!",
+        "Ready to build {project}?",
+      },
     },
   },
 })
@@ -280,6 +329,10 @@ require("ascii-animation").setup({
 | `content.builtin_messages` | boolean | `true` | Use built-in taglines |
 | `content.styles` | table/nil | `nil` | Filter styles: `{"blocks", "gradient", "isometric"}` |
 | `content.weekend_override` | boolean | `true` | Use weekend content on Sat/Sun |
+| `content.placeholders` | table | `{}` | Override auto-detected placeholder values |
+| `content.placeholders.name` | string | auto | User's name (auto: git user.name) |
+| `content.placeholders.project` | string | auto | Project name (auto: cwd basename) |
+| `content.placeholders.date_format` | string | `"%B %d, %Y"` | Date format string |
 | `content.custom_arts` | table | `{}` | User-defined arts by period |
 | `content.custom_messages` | table | `{}` | User-defined messages by period |
 
@@ -332,6 +385,28 @@ ascii.list_arts()                        -- All art IDs
 ascii.list_arts_for_period("morning")    -- Art IDs for period
 ascii.get_art_by_id("morning_blocks_1")  -- Specific art by ID
 ascii.get_styles()                       -- {"blocks", "gradient", "isometric"}
+```
+
+### Placeholders API
+
+```lua
+local placeholders = require("ascii-animation").placeholders
+
+-- Process a string with placeholders
+local text = placeholders.process("Hello, {name}! Working on {project}?")
+-- Returns: "Hello, John! Working on my-project?"
+
+-- Resolve a single placeholder
+placeholders.resolve("name")     -- "John"
+placeholders.resolve("project")  -- "my-project"
+placeholders.resolve("time")     -- "morning"
+placeholders.resolve("version")  -- "v0.10.0"
+
+-- List available placeholders
+placeholders.list_placeholders() -- {"name", "project", "time", "date", "version", "plugin_count"}
+
+-- Clear cached values (useful for testing)
+placeholders.clear_cache()
 ```
 
 ### Advanced Usage

--- a/lua/ascii-animation/config.lua
+++ b/lua/ascii-animation/config.lua
@@ -40,6 +40,14 @@ M.defaults = {
     custom_arts = {},            -- User-defined arts by period
     custom_messages = {},        -- User-defined messages by period
 
+    -- Personalization placeholders
+    -- Supported: {name}, {project}, {time}, {date}, {version}, {plugin_count}
+    placeholders = {
+      -- name = "Developer",     -- Override auto-detected git user.name
+      -- project = nil,          -- Override auto-detected project name
+      -- date_format = "%B %d, %Y",  -- Custom date format
+    },
+
     -- Time configuration
     time_periods = {
       morning   = { start = 5,  stop = 12 },

--- a/lua/ascii-animation/content/init.lua
+++ b/lua/ascii-animation/content/init.lua
@@ -5,6 +5,7 @@ local config = require("ascii-animation.config")
 local time = require("ascii-animation.time")
 local arts = require("ascii-animation.content.arts")
 local messages = require("ascii-animation.content.messages")
+local placeholders = require("ascii-animation.placeholders")
 
 local M = {}
 
@@ -91,7 +92,9 @@ function M.get_message_for_period(period)
     return nil
   end
 
-  return all_messages[math.random(#all_messages)]
+  local message = all_messages[math.random(#all_messages)]
+  -- Process placeholders at render time
+  return placeholders.process(message)
 end
 
 -- Get a complete header (art + message) for the current time period

--- a/lua/ascii-animation/content/messages/taglines.lua
+++ b/lua/ascii-animation/content/messages/taglines.lua
@@ -18,6 +18,10 @@ M.messages = {
     "New beginnings.",
     "Dawn of ideas.",
     "Wake up & code.",
+    -- Personalized (with placeholders)
+    "Good {time}, {name}!",
+    "Welcome back to {project}.",
+    "Ready to build {project}?",
     -- Philosophical
     "Today writes tomorrow's history.",
     "The void awaits your creation.",
@@ -68,6 +72,10 @@ M.messages = {
     "Push through.",
     "Stay sharp.",
     "Full steam ahead.",
+    -- Personalized (with placeholders)
+    "Good {time}, {name}!",
+    "{project} awaits your code.",
+    "Neovim {version} at your service.",
     -- Philosophical
     "The middle path leads to completion.",
     "Progress over perfection.",
@@ -118,6 +126,10 @@ M.messages = {
     "Wrap it up.",
     "Twilight coding.",
     "Calm focus.",
+    -- Personalized (with placeholders)
+    "Good {time}, {name}!",
+    "Wrapping up {project}.",
+    "{date} — Make it count.",
     -- Philosophical
     "Dusk teaches us to release.",
     "Tomorrow inherits today's work.",
@@ -169,6 +181,10 @@ M.messages = {
     "Night owl vibes.",
     "Darkness, creativity.",
     "3am thoughts.",
+    -- Personalized (with placeholders)
+    "Late {time}, {name}.",
+    "Neovim {version} • {plugin_count} plugins loaded.",
+    "The night belongs to {project}.",
     -- Philosophical
     "In darkness, we see clearly.",
     "The void speaks in functions.",
@@ -222,6 +238,10 @@ M.messages = {
     "Explore & learn.",
     "No deadlines.",
     "Pure joy.",
+    -- Personalized (with placeholders)
+    "Happy {time}, {name}!",
+    "Weekend vibes in {project}.",
+    "{date} — Your time to create.",
     -- Philosophical
     "Freedom is the root of creation.",
     "Play is the highest form of research.",

--- a/lua/ascii-animation/init.lua
+++ b/lua/ascii-animation/init.lua
@@ -5,6 +5,7 @@ local config = require("ascii-animation.config")
 local animation = require("ascii-animation.animation")
 local time = require("ascii-animation.time")
 local content = require("ascii-animation.content")
+local placeholders = require("ascii-animation.placeholders")
 
 local M = {}
 
@@ -154,5 +155,6 @@ end
 -- Expose content module for advanced usage
 M.content = content
 M.time = time
+M.placeholders = placeholders
 
 return M

--- a/lua/ascii-animation/placeholders.lua
+++ b/lua/ascii-animation/placeholders.lua
@@ -1,0 +1,162 @@
+-- Placeholder resolution for ascii-animation
+-- Replaces tokens like {name}, {project}, etc. with dynamic values
+
+local config = require("ascii-animation.config")
+local time = require("ascii-animation.time")
+
+local M = {}
+
+-- Cache for values that don't change during session
+local value_cache = {}
+
+-- Get user name from config or git
+local function get_name()
+  -- Check config first
+  local opts = config.options.content or {}
+  local placeholders = opts.placeholders or {}
+  if placeholders.name then
+    return placeholders.name
+  end
+
+  -- Try to get from git config
+  if value_cache.git_name == nil then
+    local handle = io.popen("git config user.name 2>/dev/null")
+    if handle then
+      local result = handle:read("*a")
+      handle:close()
+      result = result:gsub("^%s*(.-)%s*$", "%1") -- trim whitespace
+      value_cache.git_name = result ~= "" and result or false
+    else
+      value_cache.git_name = false
+    end
+  end
+
+  return value_cache.git_name or nil
+end
+
+-- Get current project/directory name
+local function get_project()
+  -- Check config first
+  local opts = config.options.content or {}
+  local placeholders = opts.placeholders or {}
+  if placeholders.project then
+    return placeholders.project
+  end
+
+  -- Get from current working directory
+  local cwd = vim.fn.getcwd()
+  return vim.fn.fnamemodify(cwd, ":t")
+end
+
+-- Get time-based greeting
+local function get_time_greeting()
+  local period = time.get_current_period()
+  local greetings = {
+    morning = "morning",
+    afternoon = "afternoon",
+    evening = "evening",
+    night = "night",
+    weekend = "weekend",
+  }
+  return greetings[period] or "day"
+end
+
+-- Get current date
+local function get_date()
+  -- Check config for custom format
+  local opts = config.options.content or {}
+  local placeholders = opts.placeholders or {}
+  local format = placeholders.date_format or "%B %d, %Y"
+  return os.date(format)
+end
+
+-- Get Neovim version
+local function get_version()
+  if value_cache.nvim_version == nil then
+    local v = vim.version()
+    value_cache.nvim_version = string.format("v%d.%d.%d", v.major, v.minor, v.patch)
+  end
+  return value_cache.nvim_version
+end
+
+-- Get number of loaded plugins
+local function get_plugin_count()
+  -- Try lazy.nvim first
+  local ok, lazy = pcall(require, "lazy")
+  if ok and lazy.stats then
+    local stats = lazy.stats()
+    return tostring(stats.count or 0)
+  end
+
+  -- Try packer.nvim
+  local packer_ok, packer_plugins = pcall(function()
+    return _G.packer_plugins
+  end)
+  if packer_ok and packer_plugins then
+    local count = 0
+    for _ in pairs(packer_plugins) do
+      count = count + 1
+    end
+    return tostring(count)
+  end
+
+  -- Count loaded packages as fallback
+  local count = 0
+  for _ in pairs(package.loaded) do
+    count = count + 1
+  end
+  return tostring(count)
+end
+
+-- Placeholder resolvers
+local resolvers = {
+  name = get_name,
+  project = get_project,
+  time = get_time_greeting,
+  date = get_date,
+  version = get_version,
+  plugin_count = get_plugin_count,
+}
+
+-- Resolve a single placeholder
+function M.resolve(placeholder)
+  local resolver = resolvers[placeholder]
+  if resolver then
+    return resolver()
+  end
+
+  -- Check custom placeholders in config
+  local opts = config.options.content or {}
+  local custom = opts.placeholders or {}
+  return custom[placeholder]
+end
+
+-- Process a string and replace all placeholders
+function M.process(text)
+  if not text or type(text) ~= "string" then
+    return text
+  end
+
+  -- Find and replace all {placeholder} patterns
+  return text:gsub("{(%w+)}", function(placeholder)
+    local value = M.resolve(placeholder)
+    if value then
+      return value
+    else
+      -- Remove unresolved placeholders
+      return ""
+    end
+  end)
+end
+
+-- Clear the value cache (useful for testing or refreshing)
+function M.clear_cache()
+  value_cache = {}
+end
+
+-- Get list of available placeholder names
+function M.list_placeholders()
+  return { "name", "project", "time", "date", "version", "plugin_count" }
+end
+
+return M


### PR DESCRIPTION
## Summary
- Add `placeholders.lua` module for resolving tokens like `{name}`, `{project}`, `{time}`, `{date}`, `{version}`, `{plugin_count}`
- Auto-detect values from git config, cwd, and Neovim state
- Process placeholders at render time in taglines

## Test plan
- [x] Restart Neovim and run `:lua print(require('ascii-animation.placeholders').resolve('name'))`
- [x] Verify `{project}` returns current directory name
- [x] Test full integration with `:lua print(require('ascii-animation').get_message())`

Closes #3