### PR TITLE
feat: add wave animation effect

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ end
 **Current settings in :AsciiSettings:**
 
 Animation:
-- `effect` - Animation effect (chaos, typewriter, diagonal, lines, matrix, random)
+- `effect` - Animation effect (chaos, typewriter, diagonal, lines, matrix, wave, random)
 - `ambient` - Ambient effect (none, glitch, shimmer)
 - `loop` - Loop mode toggle
 - `steps` - Animation steps (10-100)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cinematic text animation for Neovim dashboards. Watch your ASCII art materialize
 
 ## Features
 
-- Six **animation effects**: chaos, typewriter, diagonal, lines, matrix, and random
+- Seven **animation effects**: chaos, typewriter, diagonal, lines, matrix, wave, and random
 - **Loop mode**: continuous animation replay with optional reverse
 - **Ambient effects**: subtle glitch or shimmer after animation completes
 - **Ease-in-out** timing: slow start → fast middle → slow finish
@@ -48,7 +48,11 @@ Cinematic text animation for Neovim dashboards. Watch your ASCII art materialize
   opts = {
     animation = {
       enabled = true,
-      effect = "chaos",  -- "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "random"
+      effect = "chaos",  -- "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "wave" | "random"
+      effect_options = {
+        origin = "center",  -- Wave origin: "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right" | "top" | "bottom" | "left" | "right"
+        speed = 1.0,        -- Wave propagation speed multiplier
+      },
       steps = 40,        -- Total animation steps
       min_delay = 20,    -- Fastest frame delay (ms)
       max_delay = 120,   -- Slowest frame delay (ms)
@@ -414,7 +418,9 @@ animation = {
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `animation.enabled` | boolean | `true` | Enable/disable animation |
-| `animation.effect` | string | `"chaos"` | Animation effect: `"chaos"`, `"typewriter"`, `"diagonal"`, `"lines"`, `"matrix"`, or `"random"` |
+| `animation.effect` | string | `"chaos"` | Animation effect: `"chaos"`, `"typewriter"`, `"diagonal"`, `"lines"`, `"matrix"`, `"wave"`, or `"random"` |
+| `animation.effect_options.origin` | string | `"center"` | Wave effect origin point (see Wave Effect below) |
+| `animation.effect_options.speed` | number | `1.0` | Wave propagation speed multiplier |
 | `animation.steps` | number | `40` | Total animation steps (more = smoother) |
 | `animation.min_delay` | number | `20` | Fastest frame delay in ms (middle of animation) |
 | `animation.max_delay` | number | `120` | Slowest frame delay in ms (start/end) |
@@ -570,8 +576,28 @@ local delay = animation.get_frame_delay(10, 40)  -- Frame 10 of 40
 2. **Staggered**: Each character has unique timing based on position
 3. **Chaos**: Falling characters display random matrix-style symbols
 
+### Wave Effect
+1. **Ripple**: Characters reveal in an expanding circular pattern from an origin point
+2. **Origin**: Configurable starting point - center, corners, or edges
+3. **Organic**: Creates water-like ripple reveal pattern using euclidean distance
+
+**Origin Options:**
+- `"center"` (default) - Ripple expands from the center
+- `"top-left"`, `"top-right"`, `"bottom-left"`, `"bottom-right"` - Corner origins
+- `"top"`, `"bottom"`, `"left"`, `"right"` - Edge origins
+
+```lua
+animation = {
+  effect = "wave",
+  effect_options = {
+    origin = "center",  -- Starting point for the wave
+    speed = 1.0,        -- 1.0 = normal, >1 = faster, <1 = slower
+  },
+}
+```
+
 ### Random Effect
-1. **Variety**: Randomly selects one of the five effects each time animation starts
+1. **Variety**: Randomly selects one of the six effects each time animation starts
 2. **Loop variety**: When looping, picks a new random effect for each cycle
 
 All effects use Neovim's extmarks with virtual text overlay, preserving your original buffer content and highlights.

--- a/lua/ascii-animation/commands.lua
+++ b/lua/ascii-animation/commands.lua
@@ -398,7 +398,7 @@ local function update_stats_content()
   local fav_count = #config.favorites
 
   -- Effect options for display
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "random" }
+  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "random" }
   local effect_idx = 1
   for i, e in ipairs(effects) do
     if e == effect then effect_idx = i break end
@@ -453,7 +453,7 @@ end
 
 -- Cycle through effect options
 local function cycle_effect(delta)
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "random" }
+  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "random" }
   local current = config.options.animation.effect
   local idx = 1
   for i, e in ipairs(effects) do
@@ -558,7 +558,7 @@ function M.stats()
   local period = time.get_current_period()
   local fav_count = #config.favorites
 
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "random" }
+  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "random" }
   local effect_idx = 1
   for i, e in ipairs(effects) do
     if e == effect then effect_idx = i break end

--- a/lua/ascii-animation/config.lua
+++ b/lua/ascii-animation/config.lua
@@ -8,8 +8,15 @@ M.defaults = {
   -- Animation settings
   animation = {
     enabled = true,
-    -- Animation effect: "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "random"
+    -- Animation effect: "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "wave" | "random"
     effect = "chaos",
+    -- Effect-specific options (used by wave effect)
+    effect_options = {
+      -- Wave effect origin: "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right" | "top" | "bottom" | "left" | "right"
+      origin = "center",
+      -- Wave propagation speed multiplier (1.0 = normal, >1 = faster, <1 = slower)
+      speed = 1.0,
+    },
     -- Total steps in the animation
     steps = 40,
     -- Frame delay range (ms)


### PR DESCRIPTION
## Summary
- Add wave effect that creates ripple reveal from configurable origin point
- Support 9 origin points: center, 4 corners, 4 edges
- Add `effect_options.origin` and `effect_options.speed` config options

Closes #11

## Test plan
- [ ] Test wave effect with `effect = "wave"`
- [ ] Test different origins (center, top-left, bottom-right, etc.)
- [ ] Test speed multiplier (0.5, 1.0, 1.5)
- [ ] Verify effect appears in `:AsciiSettings`

🤖 Generated with [Claude Code](https://claude.ai/code)