### PR TITLE
feat: add explode/implode animation effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cinematic text animation for Neovim dashboards. Watch your ASCII art materialize
 
 ## Features
 
-- Six **animation effects**: chaos, typewriter, diagonal, lines, matrix, and random
+- Eight **animation effects**: chaos, typewriter, diagonal, lines, matrix, explode, implode, and random
 - **Loop mode**: continuous animation replay with optional reverse
 - **Ambient effects**: subtle glitch or shimmer after animation completes
 - **Ease-in-out** timing: slow start → fast middle → slow finish
@@ -48,7 +48,7 @@ Cinematic text animation for Neovim dashboards. Watch your ASCII art materialize
   opts = {
     animation = {
       enabled = true,
-      effect = "chaos",  -- "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "random"
+      effect = "chaos",  -- "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "explode" | "implode" | "random"
       steps = 40,        -- Total animation steps
       min_delay = 20,    -- Fastest frame delay (ms)
       max_delay = 120,   -- Slowest frame delay (ms)
@@ -414,7 +414,7 @@ animation = {
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `animation.enabled` | boolean | `true` | Enable/disable animation |
-| `animation.effect` | string | `"chaos"` | Animation effect: `"chaos"`, `"typewriter"`, `"diagonal"`, `"lines"`, `"matrix"`, or `"random"` |
+| `animation.effect` | string | `"chaos"` | Animation effect: `"chaos"`, `"typewriter"`, `"diagonal"`, `"lines"`, `"matrix"`, `"explode"`, `"implode"`, or `"random"` |
 | `animation.steps` | number | `40` | Total animation steps (more = smoother) |
 | `animation.min_delay` | number | `20` | Fastest frame delay in ms (middle of animation) |
 | `animation.max_delay` | number | `120` | Slowest frame delay in ms (start/end) |
@@ -570,8 +570,18 @@ local delay = animation.get_frame_delay(10, 40)  -- Frame 10 of 40
 2. **Staggered**: Each character has unique timing based on position
 3. **Chaos**: Falling characters display random matrix-style symbols
 
+### Explode Effect
+1. **Center-out**: Characters reveal from the center of each line outward to the edges
+2. **Scatter**: Unrevealed characters display as chaos symbols, creating a scatter effect
+3. **Snap**: Final phase quickly reveals remaining edge characters for a snappy finish
+
+### Implode Effect
+1. **Edge-in**: Characters converge from the edges toward the center
+2. **Converge**: Creates the visual effect of text collapsing inward
+3. **Snap**: Final phase quickly locks center characters into place
+
 ### Random Effect
-1. **Variety**: Randomly selects one of the five effects each time animation starts
+1. **Variety**: Randomly selects one of the seven effects each time animation starts
 2. **Loop variety**: When looping, picks a new random effect for each cycle
 
 All effects use Neovim's extmarks with virtual text overlay, preserving your original buffer content and highlights.

--- a/lua/ascii-animation/commands.lua
+++ b/lua/ascii-animation/commands.lua
@@ -398,7 +398,7 @@ local function update_stats_content()
   local fav_count = #config.favorites
 
   -- Effect options for display
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "random" }
+  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "explode", "implode", "random" }
   local effect_idx = 1
   for i, e in ipairs(effects) do
     if e == effect then effect_idx = i break end
@@ -453,7 +453,7 @@ end
 
 -- Cycle through effect options
 local function cycle_effect(delta)
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "random" }
+  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "explode", "implode", "random" }
   local current = config.options.animation.effect
   local idx = 1
   for i, e in ipairs(effects) do
@@ -558,7 +558,7 @@ function M.stats()
   local period = time.get_current_period()
   local fav_count = #config.favorites
 
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "random" }
+  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "explode", "implode", "random" }
   local effect_idx = 1
   for i, e in ipairs(effects) do
     if e == effect then effect_idx = i break end

--- a/lua/ascii-animation/config.lua
+++ b/lua/ascii-animation/config.lua
@@ -8,7 +8,7 @@ M.defaults = {
   -- Animation settings
   animation = {
     enabled = true,
-    -- Animation effect: "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "random"
+    -- Animation effect: "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "explode" | "implode" | "random"
     effect = "chaos",
     -- Total steps in the animation
     steps = 40,


### PR DESCRIPTION
## Summary
- Add explode effect that reveals from center outward explosively
- Add implode effect that reveals from edges inward
- Two complementary animation styles

Closes #16

## Test plan
- [ ] Test explode effect with `effect = "explode"`
- [ ] Test implode effect with `effect = "implode"`
- [ ] Verify both effects appear in `:AsciiSettings`

🤖 Generated with [Claude Code](https://claude.ai/code)