### PR TITLE
feat: add scramble, rain, spiral, explode, implode effects

### DIFF
--- a/lua/ascii-animation/commands.lua
+++ b/lua/ascii-animation/commands.lua
@@ -398,7 +398,7 @@ local function update_stats_content()
   local fav_count = #config.favorites
 
   -- Effect options for display
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "random" }
+  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "scramble", "rain", "spiral", "explode", "implode", "random" }
   local effect_idx = 1
   for i, e in ipairs(effects) do
     if e == effect then effect_idx = i break end
@@ -453,7 +453,7 @@ end
 
 -- Cycle through effect options
 local function cycle_effect(delta)
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "random" }
+  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "scramble", "rain", "spiral", "explode", "implode", "random" }
   local current = config.options.animation.effect
   local idx = 1
   for i, e in ipairs(effects) do
@@ -558,7 +558,7 @@ function M.stats()
   local period = time.get_current_period()
   local fav_count = #config.favorites
 
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "random" }
+  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "scramble", "rain", "spiral", "explode", "implode", "random" }
   local effect_idx = 1
   for i, e in ipairs(effects) do
     if e == effect then effect_idx = i break end

--- a/lua/ascii-animation/config.lua
+++ b/lua/ascii-animation/config.lua
@@ -8,7 +8,7 @@ M.defaults = {
   -- Animation settings
   animation = {
     enabled = true,
-    -- Animation effect: "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "wave" | "fade" | "random"
+    -- Animation effect: "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "wave" | "fade" | "scramble" | "rain" | "spiral" | "explode" | "implode" | "random"
     effect = "chaos",
     -- Effect-specific options (used by wave effect)
     effect_options = {


### PR DESCRIPTION
## Summary
- **scramble**: Password reveal / slot machine effect with configurable stagger
- **rain**: Bottom-up drip reveal with per-column timing variation
- **spiral**: Archimedean spiral reveal from center (outward/inward)
- **explode**: Center-outward burst reveal with scatter
- **implode**: Edge-inward converging reveal

Closes #13, #14, #15, #16

## Test plan
- [ ] Test each effect via `:AsciiSettings`
- [ ] Verify all effects appear in settings cycle

🤖 Generated with [Claude Code](https://claude.ai/code)