### PR TITLE
feat: enhanced AsciiSettings with live preview and complete options

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Cinematic text animation for Neovim dashboards. Watch your ASCII art materialize
 
 ## Features
 
-- Eight **animation effects**: chaos, typewriter, diagonal, lines, matrix, wave, fade, and random
+- 14 **animation effects**: chaos, typewriter, diagonal, lines, matrix, wave, fade, scramble, rain, spiral, explode, implode, glitch, and random
 - **Loop mode**: continuous animation replay with optional reverse
 - **Ambient effects**: subtle glitch or shimmer after animation completes
 - **Ease-in-out** timing: slow start → fast middle → slow finish
@@ -48,10 +48,29 @@ Cinematic text animation for Neovim dashboards. Watch your ASCII art materialize
   opts = {
     animation = {
       enabled = true,
-      effect = "chaos",  -- "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "wave" | "fade" | "random"
+      -- Effect: "chaos" | "typewriter" | "diagonal" | "lines" | "matrix" | "wave" |
+      --         "fade" | "scramble" | "rain" | "spiral" | "explode" | "implode" | "glitch" | "random"
+      effect = "chaos",
       effect_options = {
-        origin = "center",  -- Wave origin: "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right" | "top" | "bottom" | "left" | "right"
+        -- Wave options
+        origin = "center",  -- "center" | "top-left" | "top-right" | "bottom-left" | "bottom-right" | "top" | "bottom" | "left" | "right"
         speed = 1.0,        -- Wave propagation speed multiplier
+        -- Glitch options
+        glitch = {
+          intensity = 0.5,       -- Glitch amount (0.0-1.0)
+          block_chance = 0.2,    -- Probability of block glitching
+          block_size = 5,        -- Max size of glitch blocks
+          resolve_speed = 1.0,   -- Resolution speed
+        },
+        -- Scramble options
+        stagger = "left",   -- "left" | "right" | "center" | "random"
+        cycles = 5,         -- Scramble cycles before settling
+        -- Spiral options
+        direction = "outward",   -- "outward" | "inward"
+        rotation = "clockwise",  -- "clockwise" | "counter"
+        tightness = 1.0,         -- Spiral tightness (0.5-2.0)
+        -- Fade options
+        highlight_count = 10,    -- Brightness levels (5-20)
       },
       steps = 40,        -- Total animation steps
       min_delay = 20,    -- Fastest frame delay (ms)
@@ -304,29 +323,65 @@ Interactive keybindings:
 
 ### `:AsciiSettings`
 
-Opens an interactive settings panel:
+Opens an interactive settings panel with **live preview**:
 
 ```vim
 :AsciiSettings
 ```
 
-Features:
-- View library stats (arts, taglines, styles)
+**Features:**
+- **Live preview panel**: See animation changes instantly in a side-by-side preview
 - Change animation effect, ambient effect, loop mode, steps
+- **Effect-specific options**: Configure wave origin, glitch intensity, spiral direction, and more
+- **Timing settings**: Adjust min/max delays, loop delay, ambient interval
 - Settings are automatically saved and persist across sessions
 - Press `R` to reset to defaults
 
-Keybindings:
-- `e`/`E`: cycle effect
-- `a`/`A`: cycle ambient
+**Main Menu Keybindings:**
+- `e`/`E`: cycle effect (14 effects)
+- `o`: open effect options (for wave, glitch, scramble, spiral, fade)
+- `a`/`A`: cycle ambient effect
 - `l`: toggle loop
-- `s`/`S`: adjust steps
+- `s`/`S`: adjust steps (±5)
+- `t`: open timing settings
 - `m`/`M`: cycle random mode (always/daily/session)
 - `n`: toggle no-repeat
-- `w`/`W`: adjust favorites weight
-- `r`: refresh dashboard
+- `w`/`W`: adjust favorites weight (±10%)
+- `Space`: replay preview animation
 - `R`: reset to defaults
-- `p`: open preview
+- `q`/`Esc`: close
+
+**Effect Options (press `o`):**
+
+*Wave:*
+- `o`/`O`: cycle origin (center, top, bottom, left, right, corners)
+- `s`/`S`: adjust speed (±0.1)
+
+*Glitch:*
+- `i`/`I`: adjust intensity (±0.1)
+- `b`/`B`: adjust block chance (±0.1)
+- `s`/`S`: adjust block size (±1)
+- `r`: adjust resolve speed (±0.1)
+
+*Scramble:*
+- `s`/`S`: cycle stagger (left, right, center, random)
+- `c`/`C`: adjust cycles (±1)
+
+*Spiral:*
+- `d`/`D`: cycle direction (outward, inward)
+- `r`: cycle rotation (clockwise, counter)
+- `t`/`T`: adjust tightness (±0.1)
+
+*Fade:*
+- `h`/`H`: adjust highlight levels (±1, range 5-20)
+
+**Timing Settings (press `t`):**
+- `m`/`M`: adjust min delay (±10ms)
+- `x`/`X`: adjust max delay (±10ms)
+- `d`/`D`: adjust loop delay (±100ms)
+- `v`: toggle loop reverse
+- `i`/`I`: adjust ambient interval (±100ms)
+- `Backspace`: back to main menu
 
 ### `:AsciiRefresh`
 
@@ -418,9 +473,19 @@ animation = {
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `animation.enabled` | boolean | `true` | Enable/disable animation |
-| `animation.effect` | string | `"chaos"` | Animation effect: `"chaos"`, `"typewriter"`, `"diagonal"`, `"lines"`, `"matrix"`, `"wave"`, `"fade"`, or `"random"` |
-| `animation.effect_options.origin` | string | `"center"` | Wave effect origin point (see Wave Effect below) |
-| `animation.effect_options.speed` | number | `1.0` | Wave propagation speed multiplier |
+| `animation.effect` | string | `"chaos"` | Animation effect (see Effects section) |
+| `animation.effect_options.origin` | string | `"center"` | Wave origin point |
+| `animation.effect_options.speed` | number | `1.0` | Wave propagation speed |
+| `animation.effect_options.glitch.intensity` | number | `0.5` | Glitch amount (0-1) |
+| `animation.effect_options.glitch.block_chance` | number | `0.2` | Block glitch probability |
+| `animation.effect_options.glitch.block_size` | number | `5` | Max glitch block size |
+| `animation.effect_options.glitch.resolve_speed` | number | `1.0` | Glitch resolution speed |
+| `animation.effect_options.stagger` | string | `"left"` | Scramble stagger direction |
+| `animation.effect_options.cycles` | number | `5` | Scramble cycles |
+| `animation.effect_options.direction` | string | `"outward"` | Spiral direction |
+| `animation.effect_options.rotation` | string | `"clockwise"` | Spiral rotation |
+| `animation.effect_options.tightness` | number | `1.0` | Spiral tightness |
+| `animation.effect_options.highlight_count` | number | `10` | Fade brightness levels |
 | `animation.steps` | number | `40` | Total animation steps (more = smoother) |
 | `animation.min_delay` | number | `20` | Fastest frame delay in ms (middle of animation) |
 | `animation.max_delay` | number | `120` | Slowest frame delay in ms (start/end) |
@@ -600,9 +665,42 @@ animation = {
 1. **Brightness**: Text fades in from dim to bright using dynamic highlight groups
 2. **Stagger**: Top lines fade in first, creating a cascading brightness wave
 3. **Smooth**: Uses ease-in-out timing for a cinematic feel
+4. **Configurable**: Adjust `highlight_count` (5-20) for smoother or more stepped fade
+
+### Scramble Effect
+1. **Slot machine**: Characters cycle through random symbols before settling
+2. **Stagger**: Characters settle in order based on stagger direction (left, right, center, random)
+3. **Configurable**: Adjust `cycles` for longer/shorter scramble duration
+
+### Rain Effect
+1. **Falling**: Characters "rain" down and stack from the bottom up
+2. **Column-based**: Each column has unique timing for natural rain feel
+3. **Atmospheric**: Creates a digital rain aesthetic
+
+### Spiral Effect
+1. **Geometric**: Characters reveal in a spiral pattern from center or edges
+2. **Direction**: Choose `outward` (center→edge) or `inward` (edge→center)
+3. **Rotation**: Select `clockwise` or `counter`-clockwise spiral
+4. **Tightness**: Adjust spiral coil density (0.5-2.0)
+
+### Explode Effect
+1. **Outward**: Characters reveal from center outward like an explosion
+2. **Radial**: Creates expanding ring pattern from the middle
+3. **Dynamic**: Fast middle, slowing at edges
+
+### Implode Effect
+1. **Inward**: Characters reveal from edges inward, opposite of explode
+2. **Converging**: Creates collapsing effect toward center
+3. **Dramatic**: Good for attention-grabbing reveals
+
+### Glitch Effect
+1. **Cyberpunk**: Characters progressively stabilize through digital corruption
+2. **Block glitches**: Random rectangular areas show corrupted characters
+3. **Multi-highlight**: Glitched sections use varied error colors
+4. **Configurable**: Adjust intensity, block chance, block size, and resolve speed
 
 ### Random Effect
-1. **Variety**: Randomly selects one of the six effects each time animation starts
+1. **Variety**: Randomly selects one of the 13 effects each time animation starts
 2. **Loop variety**: When looping, picks a new random effect for each cycle
 
 All effects use Neovim's extmarks with virtual text overlay, preserving your original buffer content and highlights.

--- a/lua/ascii-animation/animation.lua
+++ b/lua/ascii-animation/animation.lua
@@ -10,7 +10,7 @@ local ambient_timer = nil
 
 -- Fade effect state
 local fade_state = {
-  highlight_count = 10,     -- Number of brightness levels
+  highlight_count = nil,    -- Number of brightness levels (from config)
   base_highlight = nil,     -- Track which highlight was used to create groups
 }
 
@@ -233,10 +233,16 @@ end
 
 -- Create fade highlight groups with varying brightness
 local function create_fade_highlights(base_highlight)
-  -- Check if we need to recreate (different base highlight)
-  if fade_state.base_highlight == base_highlight then
+  -- Get highlight count from config
+  local effect_opts = config.options.animation.effect_options or {}
+  local new_count = effect_opts.highlight_count or 10
+
+  -- Check if we need to recreate (different base highlight or count changed)
+  if fade_state.base_highlight == base_highlight and fade_state.highlight_count == new_count then
     return
   end
+
+  fade_state.highlight_count = new_count
 
   -- Get the base highlight's foreground color
   local hl_name = base_highlight or "Normal"

--- a/lua/ascii-animation/commands.lua
+++ b/lua/ascii-animation/commands.lua
@@ -364,92 +364,244 @@ function M._list_telescope()
   }):find()
 end
 
--- State for stats window
-local stats_state = {
-  buf = nil,
-  win = nil,
+-- State for settings window (enhanced with preview)
+local settings_state = {
+  settings_buf = nil,
+  settings_win = nil,
+  preview_buf = nil,
+  preview_win = nil,
+  current_art = nil,
+  submenu = nil,  -- nil | "wave" | "glitch" | "scramble" | "spiral" | "fade" | "timing"
 }
 
--- Close stats window
-local function close_stats()
-  if stats_state.win and vim.api.nvim_win_is_valid(stats_state.win) then
-    vim.api.nvim_win_close(stats_state.win, true)
+-- Close settings windows (both panels)
+local function close_settings()
+  animation.stop()
+  if settings_state.settings_win and vim.api.nvim_win_is_valid(settings_state.settings_win) then
+    vim.api.nvim_win_close(settings_state.settings_win, true)
   end
-  if stats_state.buf and vim.api.nvim_buf_is_valid(stats_state.buf) then
-    vim.api.nvim_buf_delete(stats_state.buf, { force = true })
+  if settings_state.preview_win and vim.api.nvim_win_is_valid(settings_state.preview_win) then
+    vim.api.nvim_win_close(settings_state.preview_win, true)
   end
-  stats_state.win = nil
-  stats_state.buf = nil
+  if settings_state.settings_buf and vim.api.nvim_buf_is_valid(settings_state.settings_buf) then
+    vim.api.nvim_buf_delete(settings_state.settings_buf, { force = true })
+  end
+  if settings_state.preview_buf and vim.api.nvim_buf_is_valid(settings_state.preview_buf) then
+    vim.api.nvim_buf_delete(settings_state.preview_buf, { force = true })
+  end
+  settings_state.settings_win = nil
+  settings_state.settings_buf = nil
+  settings_state.preview_win = nil
+  settings_state.preview_buf = nil
+  settings_state.submenu = nil
 end
 
--- Update stats window content
-local function update_stats_content()
-  if not stats_state.buf or not vim.api.nvim_buf_is_valid(stats_state.buf) then
+-- Get effect-specific options submenu lines
+local function get_effect_submenu_lines(effect)
+  local opts = config.options.animation.effect_options or {}
+  local lines = {}
+
+  if effect == "wave" then
+    local origins = { "center", "top", "bottom", "left", "right", "top-left", "top-right", "bottom-left", "bottom-right" }
+    local origin_idx = 1
+    for i, o in ipairs(origins) do
+      if o == opts.origin then origin_idx = i break end
+    end
+    lines = {
+      "",
+      "  Wave Effect Options",
+      "  " .. string.rep("─", 38),
+      "",
+      string.format("  [o] Origin:  %-12s  ◀ %d/%d ▶", opts.origin or "center", origin_idx, #origins),
+      string.format("  [s] Speed:   %.1fx             ◀/▶ ±0.1", opts.speed or 1.0),
+      "",
+      "  Keys: o/s: cycle/adjust  Backspace: back",
+      "",
+    }
+  elseif effect == "glitch" then
+    local glitch = opts.glitch or {}
+    lines = {
+      "",
+      "  Glitch Effect Options",
+      "  " .. string.rep("─", 38),
+      "",
+      string.format("  [i] Intensity:     %.1f        ◀/▶ ±0.1", glitch.intensity or 0.5),
+      string.format("  [b] Block chance:  %.1f        ◀/▶ ±0.1", glitch.block_chance or 0.2),
+      string.format("  [s] Block size:    %d          ◀/▶ ±1", glitch.block_size or 5),
+      string.format("  [r] Resolve speed: %.1f        ◀/▶ ±0.1", glitch.resolve_speed or 1.0),
+      "",
+      "  Keys: adjust with key  Backspace: back",
+      "",
+    }
+  elseif effect == "scramble" then
+    local staggers = { "left", "right", "center", "random" }
+    local stagger_idx = 1
+    for i, s in ipairs(staggers) do
+      if s == opts.stagger then stagger_idx = i break end
+    end
+    lines = {
+      "",
+      "  Scramble Effect Options",
+      "  " .. string.rep("─", 38),
+      "",
+      string.format("  [s] Stagger: %-8s       ◀ %d/%d ▶", opts.stagger or "left", stagger_idx, #staggers),
+      string.format("  [c] Cycles:  %d              ◀/▶ ±1", opts.cycles or 5),
+      "",
+      "  Keys: s/c: cycle/adjust  Backspace: back",
+      "",
+    }
+  elseif effect == "spiral" then
+    local directions = { "outward", "inward" }
+    local dir_idx = opts.direction == "inward" and 2 or 1
+    local rotations = { "clockwise", "counter" }
+    local rot_idx = opts.rotation == "counter" and 2 or 1
+    lines = {
+      "",
+      "  Spiral Effect Options",
+      "  " .. string.rep("─", 38),
+      "",
+      string.format("  [d] Direction: %-10s   ◀ %d/%d ▶", opts.direction or "outward", dir_idx, #directions),
+      string.format("  [r] Rotation:  %-10s   ◀ %d/%d ▶", opts.rotation or "clockwise", rot_idx, #rotations),
+      string.format("  [t] Tightness: %.1f           ◀/▶ ±0.1", opts.tightness or 1.0),
+      "",
+      "  Keys: d/r/t: cycle/adjust  Backspace: back",
+      "",
+    }
+  elseif effect == "fade" then
+    lines = {
+      "",
+      "  Fade Effect Options",
+      "  " .. string.rep("─", 38),
+      "",
+      string.format("  [h] Highlight levels: %d     ◀/▶ ±1", opts.highlight_count or 10),
+      "",
+      "  More levels = smoother fade (5-20)",
+      "",
+      "  Keys: h: adjust  Backspace: back",
+      "",
+    }
+  end
+
+  return lines
+end
+
+-- Get timing submenu lines
+local function get_timing_submenu_lines()
+  local opts = config.options.animation
+  return {
+    "",
+    "  Animation Timing",
+    "  " .. string.rep("─", 38),
+    "",
+    string.format("  [m] Min delay:       %dms      ◀/▶ ±10", opts.min_delay),
+    string.format("  [M] Max delay:       %dms     ◀/▶ ±10", opts.max_delay),
+    string.format("  [d] Loop delay:      %dms   ◀/▶ ±100", opts.loop_delay),
+    string.format("  [v] Loop reverse:    %s", opts.loop_reverse and "ON " or "OFF"),
+    string.format("  [i] Ambient interval: %dms  ◀/▶ ±100", opts.ambient_interval),
+    "",
+    "  Keys: adjust with key  Backspace: back",
+    "",
+  }
+end
+
+-- Check if effect has options submenu
+local function effect_has_options(effect)
+  return effect == "wave" or effect == "glitch" or effect == "scramble" or effect == "spiral" or effect == "fade"
+end
+
+-- Update settings panel content
+local function update_settings_content()
+  if not settings_state.settings_buf or not vim.api.nvim_buf_is_valid(settings_state.settings_buf) then
     return
   end
 
   local opts = config.options
-  local all_arts = content.list_arts()
-  local art_count = #all_arts
-  local message_count = content.messages.get_message_count()
-  local styles = content.get_styles()
   local effect = opts.animation.effect
-  local period = time.get_current_period()
-  local fav_count = #config.favorites
+  local lines
 
-  -- Effect options for display
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "scramble", "rain", "spiral", "explode", "implode", "glitch", "random" }
-  local effect_idx = 1
-  for i, e in ipairs(effects) do
-    if e == effect then effect_idx = i break end
+  -- Show submenu if active
+  if settings_state.submenu then
+    if settings_state.submenu == "timing" then
+      lines = get_timing_submenu_lines()
+    else
+      lines = get_effect_submenu_lines(settings_state.submenu)
+    end
+  else
+    -- Main settings view
+    local all_arts = content.list_arts()
+    local art_count = #all_arts
+    local fav_count = #config.favorites
+
+    -- Effect options for display
+    local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "scramble", "rain", "spiral", "explode", "implode", "glitch", "random" }
+    local effect_idx = 1
+    for i, e in ipairs(effects) do
+      if e == effect then effect_idx = i break end
+    end
+
+    -- Ambient options
+    local ambients = { "none", "glitch", "shimmer" }
+    local ambient_idx = 1
+    for i, a in ipairs(ambients) do
+      if a == opts.animation.ambient then ambient_idx = i break end
+    end
+
+    -- Random mode options
+    local random_modes = { "always", "daily", "session" }
+    local random_idx = 1
+    for i, m in ipairs(random_modes) do
+      if m == opts.selection.random_mode then random_idx = i break end
+    end
+
+    -- Build options indicator
+    local has_opts = effect_has_options(effect)
+    local opts_hint = has_opts and "  [o] Options..." or ""
+
+    lines = {
+      "",
+      "  Animation Settings",
+      "  " .. string.rep("─", 38),
+      "",
+      string.format("  [e] Effect:   %-10s ◀ %d/%d ▶", effect, effect_idx, #effects),
+      opts_hint,
+      string.format("  [a] Ambient:  %-10s ◀ %d/%d ▶", opts.animation.ambient, ambient_idx, #ambients),
+      string.format("  [l] Loop:     %s", opts.animation.loop and "ON " or "OFF"),
+      string.format("  [s] Steps:    %d", opts.animation.steps),
+      "  [t] Timing...",
+      "",
+      "  Selection",
+      "  " .. string.rep("─", 38),
+      string.format("  [m] Mode:     %-10s ◀ %d/%d ▶", opts.selection.random_mode, random_idx, #random_modes),
+      string.format("  [n] No repeat: %s", opts.selection.no_repeat and "ON " or "OFF"),
+      string.format("  [w] Fav weight: %d%%", config.favorites_weight),
+      "",
+      string.format("  Arts: %d (%d favs)", art_count, fav_count),
+      "",
+      "  [Space] Replay  [R] Reset  [q] Close",
+      "",
+    }
+
+    -- Remove empty options line if effect has no options
+    if not has_opts then
+      local new_lines = {}
+      for _, line in ipairs(lines) do
+        if line ~= "" or #new_lines == 0 or new_lines[#new_lines] ~= "" then
+          if line ~= opts_hint or has_opts then
+            table.insert(new_lines, line)
+          end
+        end
+      end
+      lines = new_lines
+    end
   end
 
-  -- Ambient options
-  local ambients = { "none", "glitch", "shimmer" }
-  local ambient_idx = 1
-  for i, a in ipairs(ambients) do
-    if a == opts.animation.ambient then ambient_idx = i break end
-  end
-
-  -- Random mode options
-  local random_modes = { "always", "daily", "session" }
-  local random_idx = 1
-  for i, m in ipairs(random_modes) do
-    if m == opts.selection.random_mode then random_idx = i break end
-  end
-
-  local lines = {
-    "",
-    "  ASCII Animation Settings",
-    "  " .. string.rep("─", 45),
-    "",
-    string.format("  Arts:        %d available (%d favorites)", art_count, fav_count),
-    string.format("  Taglines:    %d available", message_count),
-    string.format("  Styles:      %s", table.concat(styles, ", ")),
-    string.format("  Period:      %s", period),
-    "",
-    "  Animation:",
-    "  " .. string.rep("─", 45),
-    string.format("  [e] Effect:      %-10s  ◀ %d/%d ▶", effect, effect_idx, #effects),
-    string.format("  [a] Ambient:     %-10s  ◀ %d/%d ▶", opts.animation.ambient, ambient_idx, #ambients),
-    string.format("  [l] Loop:        %s", opts.animation.loop and "ON " or "OFF"),
-    string.format("  [s] Steps:       %d", opts.animation.steps),
-    "",
-    "  Selection:",
-    "  " .. string.rep("─", 45),
-    string.format("  [m] Random mode: %-10s  ◀ %d/%d ▶", opts.selection.random_mode, random_idx, #random_modes),
-    string.format("  [n] No repeat:   %s", opts.selection.no_repeat and "ON " or "OFF"),
-    string.format("  [w] Fav weight:  %d%%", config.favorites_weight),
-    "",
-    "  Keys: e/a/m: cycle  l/n: toggle  s/w: ±adjust",
-    "  r: refresh  p: preview  R: reset  q: close",
-    "",
-  }
-
-  vim.bo[stats_state.buf].modifiable = true
-  vim.api.nvim_buf_set_lines(stats_state.buf, 0, -1, false, lines)
-  vim.bo[stats_state.buf].modifiable = false
+  vim.bo[settings_state.settings_buf].modifiable = true
+  vim.api.nvim_buf_set_lines(settings_state.settings_buf, 0, -1, false, lines)
+  vim.bo[settings_state.settings_buf].modifiable = false
 end
+
+-- Forward declaration for replay
+local replay_preview
 
 -- Cycle through effect options
 local function cycle_effect(delta)
@@ -464,7 +616,8 @@ local function cycle_effect(delta)
   elseif idx > #effects then idx = 1 end
   config.options.animation.effect = effects[idx]
   config.save()
-  update_stats_content()
+  update_settings_content()
+  replay_preview()
 end
 
 -- Cycle through ambient options
@@ -480,14 +633,15 @@ local function cycle_ambient(delta)
   elseif idx > #ambients then idx = 1 end
   config.options.animation.ambient = ambients[idx]
   config.save()
-  update_stats_content()
+  update_settings_content()
 end
 
 -- Toggle loop
 local function toggle_loop()
   config.options.animation.loop = not config.options.animation.loop
   config.save()
-  update_stats_content()
+  update_settings_content()
+  replay_preview()
 end
 
 -- Adjust steps
@@ -496,7 +650,8 @@ local function adjust_steps(delta)
   if new_steps >= 10 and new_steps <= 100 then
     config.options.animation.steps = new_steps
     config.save()
-    update_stats_content()
+    update_settings_content()
+    replay_preview()
   end
 end
 
@@ -513,14 +668,14 @@ local function cycle_random_mode(delta)
   elseif idx > #modes then idx = 1 end
   config.options.selection.random_mode = modes[idx]
   config.save()
-  update_stats_content()
+  update_settings_content()
 end
 
 -- Toggle no-repeat
 local function toggle_no_repeat()
   config.options.selection.no_repeat = not config.options.selection.no_repeat
   config.save()
-  update_stats_content()
+  update_settings_content()
 end
 
 -- Adjust favorites weight
@@ -529,144 +684,615 @@ local function adjust_fav_weight(delta)
   if new_weight >= 0 and new_weight <= 100 then
     config.favorites_weight = new_weight
     config.save()
-    update_stats_content()
+    update_settings_content()
+  end
+end
+
+-- Open effect options submenu
+local function open_effect_options()
+  local effect = config.options.animation.effect
+  if effect_has_options(effect) then
+    settings_state.submenu = effect
+    update_settings_content()
+  end
+end
+
+-- Open timing submenu
+local function open_timing_submenu()
+  settings_state.submenu = "timing"
+  update_settings_content()
+end
+
+-- Close submenu (go back)
+local function close_submenu()
+  settings_state.submenu = nil
+  update_settings_content()
+end
+
+-- Wave options adjusters
+local function cycle_wave_origin(delta)
+  local origins = { "center", "top", "bottom", "left", "right", "top-left", "top-right", "bottom-left", "bottom-right" }
+  local opts = config.options.animation.effect_options
+  local idx = 1
+  for i, o in ipairs(origins) do
+    if o == opts.origin then idx = i break end
+  end
+  idx = idx + delta
+  if idx < 1 then idx = #origins
+  elseif idx > #origins then idx = 1 end
+  opts.origin = origins[idx]
+  config.save()
+  update_settings_content()
+  replay_preview()
+end
+
+local function adjust_wave_speed(delta)
+  local opts = config.options.animation.effect_options
+  local new_speed = (opts.speed or 1.0) + delta
+  if new_speed >= 0.1 and new_speed <= 3.0 then
+    opts.speed = math.floor(new_speed * 10 + 0.5) / 10  -- Round to 1 decimal
+    config.save()
+    update_settings_content()
+    replay_preview()
+  end
+end
+
+-- Glitch options adjusters
+local function adjust_glitch_intensity(delta)
+  local glitch = config.options.animation.effect_options.glitch
+  local new_val = (glitch.intensity or 0.5) + delta
+  if new_val >= 0.1 and new_val <= 1.0 then
+    glitch.intensity = math.floor(new_val * 10 + 0.5) / 10
+    config.save()
+    update_settings_content()
+    replay_preview()
+  end
+end
+
+local function adjust_glitch_block_chance(delta)
+  local glitch = config.options.animation.effect_options.glitch
+  local new_val = (glitch.block_chance or 0.2) + delta
+  if new_val >= 0 and new_val <= 1.0 then
+    glitch.block_chance = math.floor(new_val * 10 + 0.5) / 10
+    config.save()
+    update_settings_content()
+    replay_preview()
+  end
+end
+
+local function adjust_glitch_block_size(delta)
+  local glitch = config.options.animation.effect_options.glitch
+  local new_val = (glitch.block_size or 5) + delta
+  if new_val >= 1 and new_val <= 20 then
+    glitch.block_size = new_val
+    config.save()
+    update_settings_content()
+    replay_preview()
+  end
+end
+
+local function adjust_glitch_resolve_speed(delta)
+  local glitch = config.options.animation.effect_options.glitch
+  local new_val = (glitch.resolve_speed or 1.0) + delta
+  if new_val >= 0.1 and new_val <= 3.0 then
+    glitch.resolve_speed = math.floor(new_val * 10 + 0.5) / 10
+    config.save()
+    update_settings_content()
+    replay_preview()
+  end
+end
+
+-- Scramble options adjusters
+local function cycle_scramble_stagger(delta)
+  local staggers = { "left", "right", "center", "random" }
+  local opts = config.options.animation.effect_options
+  local idx = 1
+  for i, s in ipairs(staggers) do
+    if s == opts.stagger then idx = i break end
+  end
+  idx = idx + delta
+  if idx < 1 then idx = #staggers
+  elseif idx > #staggers then idx = 1 end
+  opts.stagger = staggers[idx]
+  config.save()
+  update_settings_content()
+  replay_preview()
+end
+
+local function adjust_scramble_cycles(delta)
+  local opts = config.options.animation.effect_options
+  local new_val = (opts.cycles or 5) + delta
+  if new_val >= 1 and new_val <= 20 then
+    opts.cycles = new_val
+    config.save()
+    update_settings_content()
+    replay_preview()
+  end
+end
+
+-- Spiral options adjusters
+local function cycle_spiral_direction(delta)
+  local directions = { "outward", "inward" }
+  local opts = config.options.animation.effect_options
+  local idx = opts.direction == "inward" and 2 or 1
+  idx = idx + delta
+  if idx < 1 then idx = #directions
+  elseif idx > #directions then idx = 1 end
+  opts.direction = directions[idx]
+  config.save()
+  update_settings_content()
+  replay_preview()
+end
+
+local function cycle_spiral_rotation(delta)
+  local rotations = { "clockwise", "counter" }
+  local opts = config.options.animation.effect_options
+  local idx = opts.rotation == "counter" and 2 or 1
+  idx = idx + delta
+  if idx < 1 then idx = #rotations
+  elseif idx > #rotations then idx = 1 end
+  opts.rotation = rotations[idx]
+  config.save()
+  update_settings_content()
+  replay_preview()
+end
+
+local function adjust_spiral_tightness(delta)
+  local opts = config.options.animation.effect_options
+  local new_val = (opts.tightness or 1.0) + delta
+  if new_val >= 0.5 and new_val <= 2.0 then
+    opts.tightness = math.floor(new_val * 10 + 0.5) / 10
+    config.save()
+    update_settings_content()
+    replay_preview()
+  end
+end
+
+-- Fade options adjusters
+local function adjust_fade_highlight_count(delta)
+  local opts = config.options.animation.effect_options
+  local new_val = (opts.highlight_count or 10) + delta
+  if new_val >= 5 and new_val <= 20 then
+    opts.highlight_count = new_val
+    config.save()
+    update_settings_content()
+    replay_preview()
+  end
+end
+
+-- Timing adjusters
+local function adjust_min_delay(delta)
+  local opts = config.options.animation
+  local new_val = opts.min_delay + delta
+  if new_val >= 10 and new_val <= opts.max_delay - 10 then
+    opts.min_delay = new_val
+    config.save()
+    update_settings_content()
+    replay_preview()
+  end
+end
+
+local function adjust_max_delay(delta)
+  local opts = config.options.animation
+  local new_val = opts.max_delay + delta
+  if new_val >= opts.min_delay + 10 and new_val <= 500 then
+    opts.max_delay = new_val
+    config.save()
+    update_settings_content()
+    replay_preview()
+  end
+end
+
+local function adjust_loop_delay(delta)
+  local opts = config.options.animation
+  local new_val = opts.loop_delay + delta
+  if new_val >= 500 and new_val <= 10000 then
+    opts.loop_delay = new_val
+    config.save()
+    update_settings_content()
+  end
+end
+
+local function toggle_loop_reverse()
+  config.options.animation.loop_reverse = not config.options.animation.loop_reverse
+  config.save()
+  update_settings_content()
+end
+
+local function adjust_ambient_interval(delta)
+  local opts = config.options.animation
+  local new_val = opts.ambient_interval + delta
+  if new_val >= 500 and new_val <= 10000 then
+    opts.ambient_interval = new_val
+    config.save()
+    update_settings_content()
   end
 end
 
 -- Reset to config defaults
 local function reset_to_defaults()
   config.clear_saved()
-  -- Reload defaults
-  config.options.animation.effect = config.defaults.animation.effect
-  config.options.animation.ambient = config.defaults.animation.ambient
-  config.options.animation.loop = config.defaults.animation.loop
-  config.options.animation.steps = config.defaults.animation.steps
   vim.notify("Settings reset to defaults", vim.log.levels.INFO)
-  update_stats_content()
+  update_settings_content()
+  replay_preview()
 end
 
--- Display interactive statistics
-function M.stats()
-  close_stats()
-
-  local opts = config.options
-  local all_arts = content.list_arts()
-  local art_count = #all_arts
-  local message_count = content.messages.get_message_count()
-  local styles = content.get_styles()
-  local effect = opts.animation.effect
-  local period = time.get_current_period()
-  local fav_count = #config.favorites
-
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "scramble", "rain", "spiral", "explode", "implode", "glitch", "random" }
-  local effect_idx = 1
-  for i, e in ipairs(effects) do
-    if e == effect then effect_idx = i break end
+-- Update preview buffer content
+local function update_preview_buffer()
+  if not settings_state.preview_buf or not vim.api.nvim_buf_is_valid(settings_state.preview_buf) then
+    return
   end
 
-  local ambients = { "none", "glitch", "shimmer" }
-  local ambient_idx = 1
-  for i, a in ipairs(ambients) do
-    if a == opts.animation.ambient then ambient_idx = i break end
+  local art = settings_state.current_art
+  if not art or not art.lines then return end
+
+  -- Build content with padding
+  local lines = { "" }
+  for _, line in ipairs(art.lines) do
+    table.insert(lines, "  " .. line)
+  end
+  table.insert(lines, "")
+  table.insert(lines, string.format("  %s", art.name or art.id))
+  table.insert(lines, "")
+
+  vim.bo[settings_state.preview_buf].modifiable = true
+  vim.api.nvim_buf_set_lines(settings_state.preview_buf, 0, -1, false, lines)
+  vim.bo[settings_state.preview_buf].modifiable = false
+end
+
+-- Replay preview animation (implements forward declaration)
+replay_preview = function()
+  if not settings_state.preview_buf or not vim.api.nvim_buf_is_valid(settings_state.preview_buf) then
+    return
   end
 
-  local random_modes = { "always", "daily", "session" }
-  local random_idx = 1
-  for i, m in ipairs(random_modes) do
-    if m == opts.selection.random_mode then random_idx = i break end
-  end
+  local art = settings_state.current_art
+  if not art then return end
 
-  local lines = {
-    "",
-    "  ASCII Animation Settings",
-    "  " .. string.rep("─", 45),
-    "",
-    string.format("  Arts:        %d available (%d favorites)", art_count, fav_count),
-    string.format("  Taglines:    %d available", message_count),
-    string.format("  Styles:      %s", table.concat(styles, ", ")),
-    string.format("  Period:      %s", period),
-    "",
-    "  Animation:",
-    "  " .. string.rep("─", 45),
-    string.format("  [e] Effect:      %-10s  ◀ %d/%d ▶", effect, effect_idx, #effects),
-    string.format("  [a] Ambient:     %-10s  ◀ %d/%d ▶", opts.animation.ambient, ambient_idx, #ambients),
-    string.format("  [l] Loop:        %s", opts.animation.loop and "ON " or "OFF"),
-    string.format("  [s] Steps:       %d", opts.animation.steps),
-    "",
-    "  Selection:",
-    "  " .. string.rep("─", 45),
-    string.format("  [m] Random mode: %-10s  ◀ %d/%d ▶", opts.selection.random_mode, random_idx, #random_modes),
-    string.format("  [n] No repeat:   %s", opts.selection.no_repeat and "ON " or "OFF"),
-    string.format("  [w] Fav weight:  %d%%", config.favorites_weight),
-    "",
-    "  Keys: e/a/m: cycle  l/n: toggle  s/w: ±adjust",
-    "  r: refresh  p: preview  R: reset  q: close",
-    "",
+  animation.stop()
+  update_preview_buffer()
+
+  vim.defer_fn(function()
+    if settings_state.preview_buf and vim.api.nvim_buf_is_valid(settings_state.preview_buf) then
+      animation.start(settings_state.preview_buf, #art.lines + 1, "Normal")
+    end
+  end, 50)
+end
+
+-- Setup keybindings for settings buffer
+local function setup_settings_keybindings(buf)
+  -- Common keybindings
+  local common_keymaps = {
+    { "q", close_settings },
+    { "<Esc>", close_settings },
+    { "<Space>", replay_preview },
+    { "R", reset_to_defaults },
   }
 
-  -- Calculate dimensions
-  local width = 52
-  local height = #lines + 2
+  for _, map in ipairs(common_keymaps) do
+    vim.keymap.set("n", map[1], map[2], { buffer = buf, nowait = true, silent = true })
+  end
 
-  local row = math.floor((vim.o.lines - height) / 2)
-  local col = math.floor((vim.o.columns - width) / 2)
+  -- Context-aware keybindings
+  -- Main menu keys
+  vim.keymap.set("n", "e", function()
+    if not settings_state.submenu then
+      cycle_effect(1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
 
-  local buf = vim.api.nvim_create_buf(false, true)
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
-  vim.bo[buf].modifiable = false
-  vim.bo[buf].bufhidden = "wipe"
+  vim.keymap.set("n", "E", function()
+    if not settings_state.submenu then
+      cycle_effect(-1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
 
-  local win = vim.api.nvim_open_win(buf, true, {
+  vim.keymap.set("n", "a", function()
+    if not settings_state.submenu then
+      cycle_ambient(1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "A", function()
+    if not settings_state.submenu then
+      cycle_ambient(-1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "l", function()
+    if not settings_state.submenu then
+      toggle_loop()
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "s", function()
+    if not settings_state.submenu then
+      adjust_steps(5)
+    elseif settings_state.submenu == "wave" then
+      adjust_wave_speed(0.1)
+    elseif settings_state.submenu == "glitch" then
+      adjust_glitch_block_size(1)
+    elseif settings_state.submenu == "scramble" then
+      cycle_scramble_stagger(1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "S", function()
+    if not settings_state.submenu then
+      adjust_steps(-5)
+    elseif settings_state.submenu == "wave" then
+      adjust_wave_speed(-0.1)
+    elseif settings_state.submenu == "glitch" then
+      adjust_glitch_block_size(-1)
+    elseif settings_state.submenu == "scramble" then
+      cycle_scramble_stagger(-1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "m", function()
+    if not settings_state.submenu then
+      cycle_random_mode(1)
+    elseif settings_state.submenu == "timing" then
+      adjust_min_delay(10)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "M", function()
+    if not settings_state.submenu then
+      cycle_random_mode(-1)
+    elseif settings_state.submenu == "timing" then
+      adjust_min_delay(-10)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "n", function()
+    if not settings_state.submenu then
+      toggle_no_repeat()
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "w", function()
+    if not settings_state.submenu then
+      adjust_fav_weight(10)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "W", function()
+    if not settings_state.submenu then
+      adjust_fav_weight(-10)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "o", function()
+    if not settings_state.submenu then
+      open_effect_options()
+    elseif settings_state.submenu == "wave" then
+      cycle_wave_origin(1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "O", function()
+    if settings_state.submenu == "wave" then
+      cycle_wave_origin(-1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "t", function()
+    if not settings_state.submenu then
+      open_timing_submenu()
+    elseif settings_state.submenu == "spiral" then
+      adjust_spiral_tightness(0.1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "T", function()
+    if settings_state.submenu == "spiral" then
+      adjust_spiral_tightness(-0.1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  -- Backspace to go back from submenu
+  vim.keymap.set("n", "<BS>", function()
+    if settings_state.submenu then
+      close_submenu()
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  -- Glitch-specific keys
+  vim.keymap.set("n", "i", function()
+    if settings_state.submenu == "glitch" then
+      adjust_glitch_intensity(0.1)
+    elseif settings_state.submenu == "timing" then
+      adjust_ambient_interval(100)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "I", function()
+    if settings_state.submenu == "glitch" then
+      adjust_glitch_intensity(-0.1)
+    elseif settings_state.submenu == "timing" then
+      adjust_ambient_interval(-100)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "b", function()
+    if settings_state.submenu == "glitch" then
+      adjust_glitch_block_chance(0.1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "B", function()
+    if settings_state.submenu == "glitch" then
+      adjust_glitch_block_chance(-0.1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "r", function()
+    if settings_state.submenu == "glitch" then
+      adjust_glitch_resolve_speed(0.1)
+    elseif settings_state.submenu == "spiral" then
+      cycle_spiral_rotation(1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  -- Scramble-specific keys
+  vim.keymap.set("n", "c", function()
+    if settings_state.submenu == "scramble" then
+      adjust_scramble_cycles(1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "C", function()
+    if settings_state.submenu == "scramble" then
+      adjust_scramble_cycles(-1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  -- Spiral-specific keys
+  vim.keymap.set("n", "d", function()
+    if settings_state.submenu == "spiral" then
+      cycle_spiral_direction(1)
+    elseif settings_state.submenu == "timing" then
+      adjust_loop_delay(100)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "D", function()
+    if settings_state.submenu == "spiral" then
+      cycle_spiral_direction(-1)
+    elseif settings_state.submenu == "timing" then
+      adjust_loop_delay(-100)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  -- Fade-specific keys
+  vim.keymap.set("n", "h", function()
+    if settings_state.submenu == "fade" then
+      adjust_fade_highlight_count(1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "H", function()
+    if settings_state.submenu == "fade" then
+      adjust_fade_highlight_count(-1)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  -- Timing-specific keys
+  vim.keymap.set("n", "x", function()
+    if settings_state.submenu == "timing" then
+      adjust_max_delay(10)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "X", function()
+    if settings_state.submenu == "timing" then
+      adjust_max_delay(-10)
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
+  vim.keymap.set("n", "v", function()
+    if settings_state.submenu == "timing" then
+      toggle_loop_reverse()
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+end
+
+-- Display interactive settings with live preview
+function M.stats()
+  close_settings()
+
+  -- Get a random art for preview
+  local period = time.get_current_period()
+  local arts = get_arts_list(period)
+  if #arts == 0 then
+    arts = get_arts_list(nil)
+  end
+  if #arts == 0 then
+    vim.notify("No arts available", vim.log.levels.WARN)
+    return
+  end
+  settings_state.current_art = arts[math.random(1, #arts)]
+
+  -- Calculate dimensions for side-by-side layout
+  local total_width = math.min(120, math.floor(vim.o.columns * 0.9))
+  local settings_width = 44
+  local preview_width = total_width - settings_width - 3  -- Gap between panels
+
+  -- Calculate art display width
+  local art = settings_state.current_art
+  local art_width = 0
+  for _, line in ipairs(art.lines) do
+    art_width = math.max(art_width, vim.fn.strdisplaywidth(line))
+  end
+  preview_width = math.max(preview_width, art_width + 6)
+
+  local settings_height = 24
+  local preview_height = #art.lines + 5
+
+  local total_height = math.max(settings_height, preview_height)
+  local row = math.floor((vim.o.lines - total_height) / 2)
+  local col = math.floor((vim.o.columns - (settings_width + preview_width + 3)) / 2)
+
+  -- Create settings buffer
+  local settings_buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[settings_buf].bufhidden = "wipe"
+
+  -- Create settings window (left panel)
+  local settings_win = vim.api.nvim_open_win(settings_buf, true, {
     relative = "editor",
-    width = width,
-    height = height,
+    width = settings_width,
+    height = settings_height,
     row = row,
     col = col,
     style = "minimal",
     border = "rounded",
-    title = " Stats & Settings ",
+    title = " Settings ",
     title_pos = "center",
   })
 
-  vim.wo[win].wrap = false
-  vim.wo[win].cursorline = false
+  vim.wo[settings_win].wrap = false
+  vim.wo[settings_win].cursorline = false
 
-  stats_state.buf = buf
-  stats_state.win = win
+  settings_state.settings_buf = settings_buf
+  settings_state.settings_win = settings_win
 
-  -- Keybindings
-  local keymaps = {
-    { "q", close_stats },
-    { "<Esc>", close_stats },
-    { "e", function() cycle_effect(1) end },
-    { "E", function() cycle_effect(-1) end },
-    { "a", function() cycle_ambient(1) end },
-    { "A", function() cycle_ambient(-1) end },
-    { "l", toggle_loop },
-    { "s", function() adjust_steps(5) end },
-    { "S", function() adjust_steps(-5) end },
-    { "m", function() cycle_random_mode(1) end },
-    { "M", function() cycle_random_mode(-1) end },
-    { "n", toggle_no_repeat },
-    { "w", function() adjust_fav_weight(10) end },
-    { "W", function() adjust_fav_weight(-10) end },
-    { "r", function() close_stats() M.refresh() end },
-    { "R", reset_to_defaults },
-    { "p", function() close_stats() M.preview() end },
-  }
+  -- Create preview buffer
+  local preview_buf = vim.api.nvim_create_buf(false, true)
+  vim.bo[preview_buf].bufhidden = "wipe"
 
-  for _, map in ipairs(keymaps) do
-    vim.keymap.set("n", map[1], map[2], { buffer = buf, nowait = true, silent = true })
-  end
+  -- Create preview window (right panel)
+  local preview_win = vim.api.nvim_open_win(preview_buf, false, {
+    relative = "editor",
+    width = preview_width,
+    height = preview_height,
+    row = row,
+    col = col + settings_width + 3,
+    style = "minimal",
+    border = "rounded",
+    title = " Live Preview ",
+    title_pos = "center",
+  })
 
-  return {
-    arts = art_count,
-    taglines = message_count,
-    styles = styles,
-    effect = effect,
-    period = period,
-    animation = opts.animation,
-  }
+  vim.wo[preview_win].wrap = false
+  vim.wo[preview_win].cursorline = false
+
+  settings_state.preview_buf = preview_buf
+  settings_state.preview_win = preview_win
+
+  -- Set up content
+  update_settings_content()
+  update_preview_buffer()
+
+  -- Set up keybindings
+  setup_settings_keybindings(settings_buf)
+
+  -- Start preview animation
+  vim.defer_fn(function()
+    if preview_buf and vim.api.nvim_buf_is_valid(preview_buf) then
+      animation.start(preview_buf, #art.lines + 1, "Normal")
+    end
+  end, 100)
 end
 
 -- Refresh animation on current buffer

--- a/lua/ascii-animation/config.lua
+++ b/lua/ascii-animation/config.lua
@@ -22,6 +22,15 @@ M.defaults = {
         block_size = 5,        -- Maximum size of glitch blocks
         resolve_speed = 1.0,   -- Speed of glitch resolution (higher = faster)
       },
+      -- Scramble effect options
+      stagger = "left",        -- "left" | "right" | "center" | "random"
+      cycles = 5,              -- Number of scramble cycles before settling
+      -- Spiral effect options
+      direction = "outward",   -- "outward" | "inward"
+      rotation = "clockwise",  -- "clockwise" | "counter"
+      tightness = 1.0,         -- Spiral tightness (0.5-2.0)
+      -- Fade effect options
+      highlight_count = 10,    -- Number of brightness levels (5-20)
     },
     -- Total steps in the animation
     steps = 40,
@@ -139,9 +148,15 @@ function M.save()
   local to_save = {
     animation = {
       effect = M.options.animation.effect,
+      effect_options = M.options.animation.effect_options,
       ambient = M.options.animation.ambient,
       loop = M.options.animation.loop,
+      loop_delay = M.options.animation.loop_delay,
+      loop_reverse = M.options.animation.loop_reverse,
       steps = M.options.animation.steps,
+      min_delay = M.options.animation.min_delay,
+      max_delay = M.options.animation.max_delay,
+      ambient_interval = M.options.animation.ambient_interval,
     },
     selection = {
       random_mode = M.options.selection.random_mode,
@@ -170,6 +185,17 @@ function M.clear_saved()
   M.favorites_weight = 70
   M.options.selection.random_mode = M.defaults.selection.random_mode
   M.options.selection.no_repeat = M.defaults.selection.no_repeat
+  -- Reset animation settings
+  M.options.animation.effect = M.defaults.animation.effect
+  M.options.animation.effect_options = vim.deepcopy(M.defaults.animation.effect_options)
+  M.options.animation.ambient = M.defaults.animation.ambient
+  M.options.animation.loop = M.defaults.animation.loop
+  M.options.animation.loop_delay = M.defaults.animation.loop_delay
+  M.options.animation.loop_reverse = M.defaults.animation.loop_reverse
+  M.options.animation.steps = M.defaults.animation.steps
+  M.options.animation.min_delay = M.defaults.animation.min_delay
+  M.options.animation.max_delay = M.defaults.animation.max_delay
+  M.options.animation.ambient_interval = M.defaults.animation.ambient_interval
 end
 
 -- Toggle favorite status for an art ID


### PR DESCRIPTION
## Summary
- Added **live preview panel** alongside settings - see animation changes instantly
- Added **effect-specific options** submenus for wave, glitch, scramble, spiral, and fade effects
- Added **timing settings** submenu for min/max delay, loop delay, and ambient interval
- All new settings persist to disk automatically

## Features

### Live Preview
The settings panel now shows a side-by-side live preview that automatically replays when any setting changes.

### Effect Options
Each configurable effect has its own submenu (press `o`):
- **Wave**: origin (9 positions), speed multiplier
- **Glitch**: intensity, block chance, block size, resolve speed
- **Scramble**: stagger direction (left/right/center/random), cycles
- **Spiral**: direction (outward/inward), rotation (clockwise/counter), tightness
- **Fade**: highlight count (5-20 brightness levels)

### Timing Settings
New timing submenu (press `t`) for fine-tuning animation:
- Min/max frame delay
- Loop delay and reverse toggle
- Ambient effect interval

## Test Plan
- [ ] Open `:AsciiSettings` and verify split layout with preview
- [ ] Change effect and verify live preview updates
- [ ] Test effect options submenus (wave, glitch, scramble, spiral, fade)
- [ ] Test timing submenu adjustments
- [ ] Verify settings persist after closing and reopening Neovim
- [ ] Test reset to defaults (`R` key)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)