### PR TITLE
feat: add animation control commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Cinematic text animation for Neovim dashboards. Watch your ASCII art materialize
   - [lazy.nvim](https://github.com/folke/lazy.nvim) starter screen
 - Fully configurable animation speed, characters, and timing
 - Respects your colorscheme and dashboard highlights
-- **User commands**: `:AsciiPreview`, `:AsciiSettings`, `:AsciiRefresh`
+- **User commands**: `:AsciiPreview`, `:AsciiSettings`, `:AsciiRefresh`, `:AsciiStop`, `:AsciiRestart`
 
 ## Installation
 
@@ -478,6 +478,22 @@ Re-runs the animation on the current buffer. Useful after returning to your dash
 
 ```vim
 :AsciiRefresh
+```
+
+### `:AsciiStop`
+
+Stops the current animation and any ambient effects. Useful for taking screenshots or when you want a static display.
+
+```vim
+:AsciiStop
+```
+
+### `:AsciiRestart`
+
+Restarts the animation from the beginning. Useful for demos or presentations.
+
+```vim
+:AsciiRestart
 ```
 
 ### `:checkhealth ascii-animation`

--- a/lua/ascii-animation/commands.lua
+++ b/lua/ascii-animation/commands.lua
@@ -1,5 +1,5 @@
 -- User commands for ascii-animation
--- Provides :AsciiPreview, :AsciiList, :AsciiStats, :AsciiRefresh
+-- Provides :AsciiPreview, :AsciiList, :AsciiSettings, :AsciiRefresh, :AsciiStop, :AsciiRestart
 
 local config = require("ascii-animation.config")
 local animation = require("ascii-animation.animation")
@@ -2197,6 +2197,20 @@ function M.register_commands()
     M.refresh()
   end, {
     desc = "Re-run animation on current buffer",
+  })
+
+  vim.api.nvim_create_user_command("AsciiStop", function()
+    animation.stop()
+    vim.notify("Animation stopped", vim.log.levels.INFO)
+  end, {
+    desc = "Stop current ASCII animation",
+  })
+
+  vim.api.nvim_create_user_command("AsciiRestart", function()
+    M.refresh()
+    vim.notify("Animation restarted", vim.log.levels.INFO)
+  end, {
+    desc = "Restart ASCII animation from beginning",
   })
 end
 

--- a/lua/ascii-animation/health.lua
+++ b/lua/ascii-animation/health.lua
@@ -262,6 +262,8 @@ local function check_commands()
     "AsciiPreview",
     "AsciiSettings",
     "AsciiRefresh",
+    "AsciiStop",
+    "AsciiRestart",
   }
 
   local all_ok = true


### PR DESCRIPTION
## Summary
- Add `:AsciiStop` command to stop current animation and ambient effects
- Add `:AsciiRestart` command to restart animation from beginning
- Update README with documentation for new commands
- Update health check to verify new commands

Closes #34

## Test plan
- [ ] Run `:AsciiStop` while animation is playing - should stop and show notification
- [ ] Run `:AsciiRestart` - should restart animation and show notification
- [ ] Run `:checkhealth ascii-animation` - should show all 5 commands registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)