### PR TITLE
fix: add Unicode font warning for charset presets

### DIFF
--- a/lua/ascii-animation/config.lua
+++ b/lua/ascii-animation/config.lua
@@ -17,6 +17,21 @@ M.char_presets = {
 -- Ordered list of preset names for cycling
 M.char_preset_names = { "default", "minimal", "matrix", "blocks", "braille", "stars", "geometric", "binary", "dots" }
 
+-- Presets that require Unicode font support (not pure ASCII)
+M.char_presets_unicode = {
+  minimal = true,
+  matrix = true,
+  blocks = true,
+  braille = true,
+  stars = true,
+  geometric = true,
+}
+
+-- Check if a preset requires Unicode font support
+function M.preset_requires_unicode(preset)
+  return M.char_presets_unicode[preset] or false
+end
+
 -- Get the current chaos characters (resolves preset to actual string)
 function M.get_chaos_chars()
   local preset = M.options.animation and M.options.animation.char_preset or "default"


### PR DESCRIPTION
## Summary
- Add warning in `:AsciiSettings` when selecting a charset that requires Unicode font support
- Add warning in `:AsciiCharset` command when setting a Unicode preset
- Mark presets as Unicode-dependent: minimal, matrix, blocks, braille, stars, geometric

**Safe presets (ASCII only):** default, binary, dots
**Unicode presets:** minimal, matrix, blocks, braille, stars, geometric

## Test plan
- [ ] Open `:AsciiSettings` and cycle to a Unicode preset (e.g., matrix) - should show "(requires Unicode font)" warning
- [ ] Cycle to a safe preset (e.g., default, binary, dots) - warning should not appear
- [ ] Run `:AsciiCharset matrix` - notification should include Unicode warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)