### PR TITLE
feat: add user-definable highlight groups for animation phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Cinematic text animation for Neovim dashboards. Watch your ASCII art materialize
   - [lazy.nvim](https://github.com/folke/lazy.nvim) starter screen
 - Fully configurable animation speed, characters, and timing
 - Respects your colorscheme and dashboard highlights
+- **Phase-based highlighting**: Customize colors for chaos, revealing, and revealed states
 - **User commands**: `:AsciiPreview`, `:AsciiSettings`, `:AsciiRefresh`, `:AsciiStop`, `:AsciiRestart`, `:AsciiCharset`
 
 ## Installation
@@ -86,6 +87,8 @@ Cinematic text animation for Neovim dashboards. Watch your ASCII art materialize
       ambient_interval = 2000,
       -- Character set preset
       char_preset = "default", -- "default" | "minimal" | "matrix" | "blocks" | "braille" | "stars" | "geometric" | "binary" | "dots"
+      -- Phase-based highlighting (see Highlight Groups section)
+      use_phase_highlights = false,
     },
     chaos_chars = "@#$%&*+=-:;!?/\\|[]{}()<>~`'^", -- Custom chars (overrides preset)
   },
@@ -402,6 +405,8 @@ Opens an interactive settings panel with **live preview**:
 - `l`: toggle loop
 - `s`/`S`: adjust steps (±5)
 - `c`/`C`: cycle charset preset (9 presets)
+- `p`: toggle phase highlights
+- `P`: open phase colors (when phase highlights enabled)
 - `t`: open timing settings
 - `m`/`M`: cycle random mode (always/daily/session)
 - `n`: toggle no-repeat
@@ -443,6 +448,16 @@ Opens an interactive settings panel with **live preview**:
 - `d`/`D`: adjust loop delay (±100ms)
 - `v`: toggle loop reverse
 - `i`/`I`: adjust ambient interval (±100ms)
+- `Backspace`: back to main menu
+
+**Phase Colors (press `P` when phase highlights enabled):**
+- `P`: cycle through color presets (Default, Cyberpunk, Ocean, Sunset, Forest, Monochrome)
+- `1`: edit Chaos color (hex input)
+- `2`: edit Revealing color (hex input)
+- `3`: edit Revealed color (hex input)
+- `4`: edit Cursor color (hex input)
+- `5`: edit Glitch color (hex input)
+- `r`: reset to default colors
 - `Backspace`: back to main menu
 
 **Styles Filter (press `y`):**
@@ -644,6 +659,7 @@ animation = {
 | `animation.ambient` | string | `"none"` | Ambient effect after animation: `"none"`, `"glitch"`, or `"shimmer"` |
 | `animation.ambient_interval` | number | `2000` | How often ambient effect triggers in ms |
 | `animation.char_preset` | string | `"default"` | Character preset: `"default"`, `"minimal"`, `"matrix"`, `"blocks"`, `"braille"`, `"stars"`, `"geometric"`, `"binary"`, `"dots"` |
+| `animation.use_phase_highlights` | boolean | `false` | Enable phase-based highlight groups (see Highlight Groups section) |
 | `animation.auto_fit` | boolean | `false` | Skip arts wider than terminal width |
 | `animation.min_width` | number | `60` | Minimum terminal width for animation |
 | `animation.fallback` | string | `"tagline"` | Fallback when terminal too narrow: `"tagline"`, `"none"`, or art ID |
@@ -900,6 +916,69 @@ animation = {
   ambient_interval = 2000, -- Trigger every 2 seconds
 }
 ```
+
+### Highlight Groups
+
+When `use_phase_highlights` is enabled, the animation uses dedicated highlight groups for different character states. This allows you to customize colors based on whether a character is in the chaos, revealing, or revealed phase.
+
+**Enable phase highlights:**
+
+```lua
+animation = {
+  use_phase_highlights = true,
+}
+```
+
+**Available highlight groups:**
+
+| Highlight Group | Default | Description |
+|-----------------|---------|-------------|
+| `AsciiAnimationChaos` | `#555555` | Unrevealed chaos characters |
+| `AsciiAnimationRevealing` | `#888888` | Characters about to reveal |
+| `AsciiAnimationRevealed` | `#ffffff` | Fully revealed characters |
+| `AsciiAnimationCursor` | `#00ff00` bold | Typewriter cursor |
+| `AsciiAnimationGlitch` | `#ff0055` | Glitch effect corruption |
+
+**Customize in your colorscheme or config:**
+
+```lua
+-- In your Neovim config (after colorscheme is loaded)
+vim.api.nvim_set_hl(0, "AsciiAnimationChaos", { fg = "#1a1a2e" })
+vim.api.nvim_set_hl(0, "AsciiAnimationRevealing", { fg = "#4a4a6a" })
+vim.api.nvim_set_hl(0, "AsciiAnimationRevealed", { link = "Title" })
+vim.api.nvim_set_hl(0, "AsciiAnimationCursor", { fg = "#00ff41", bold = true })
+vim.api.nvim_set_hl(0, "AsciiAnimationGlitch", { fg = "#ff0066", bold = true })
+```
+
+**Colorscheme integration example:**
+
+```lua
+-- In your custom colorscheme file
+local colors = {
+  chaos = "#2d2d44",
+  revealing = "#5a5a8a",
+  revealed = "#e0e0e0",
+  cursor = "#00ff41",
+  glitch = "#ff3366",
+}
+
+vim.api.nvim_set_hl(0, "AsciiAnimationChaos", { fg = colors.chaos })
+vim.api.nvim_set_hl(0, "AsciiAnimationRevealing", { fg = colors.revealing })
+vim.api.nvim_set_hl(0, "AsciiAnimationRevealed", { fg = colors.revealed })
+vim.api.nvim_set_hl(0, "AsciiAnimationCursor", { fg = colors.cursor, bold = true })
+vim.api.nvim_set_hl(0, "AsciiAnimationGlitch", { fg = colors.glitch })
+```
+
+**Using `:AsciiSettings` (recommended for quick customization):**
+
+Press `P` in the settings panel to access the Phase Colors submenu, where you can:
+- Cycle through 6 built-in presets: Default, Cyberpunk, Ocean, Sunset, Forest, Monochrome
+- Edit individual colors by pressing `1`-`5` and entering a hex color
+- Reset to defaults with `r`
+
+Settings are automatically persisted across sessions.
+
+**Note:** The plugin applies custom colors from `:AsciiSettings` first. If you want to override via your colorscheme, define the highlight groups before the animation runs. When `use_phase_highlights` is disabled (default), the animation uses the dashboard's base highlight for all characters.
 
 ## Credits
 

--- a/lua/ascii-animation/commands.lua
+++ b/lua/ascii-animation/commands.lua
@@ -507,6 +507,62 @@ local function get_timing_submenu_lines()
   }
 end
 
+-- Preset colors for phase highlights
+local phase_color_presets = {
+  -- Each preset is { name, chaos, revealing, revealed, cursor, glitch }
+  { name = "Default",   chaos = "#555555", revealing = "#888888", revealed = "#ffffff", cursor = "#00ff00", glitch = "#ff0055" },
+  { name = "Cyberpunk", chaos = "#1a1a2e", revealing = "#4a4a6a", revealed = "#00ff41", cursor = "#ff00ff", glitch = "#ff3366" },
+  { name = "Ocean",     chaos = "#1a3a4a", revealing = "#3a6a8a", revealed = "#8ad4ff", cursor = "#00ffcc", glitch = "#ff6b6b" },
+  { name = "Sunset",    chaos = "#2a1a2a", revealing = "#6a3a5a", revealed = "#ffaa77", cursor = "#ffff00", glitch = "#ff4466" },
+  { name = "Forest",    chaos = "#1a2a1a", revealing = "#3a5a3a", revealed = "#88cc88", cursor = "#ffff44", glitch = "#ff6644" },
+  { name = "Monochrome", chaos = "#333333", revealing = "#666666", revealed = "#cccccc", cursor = "#ffffff", glitch = "#999999" },
+}
+
+-- Get phase colors submenu lines
+local function get_phase_colors_submenu_lines()
+  local phase_colors = config.options.animation.phase_colors or {}
+  local defaults = { chaos = "#555555", revealing = "#888888", revealed = "#ffffff", cursor = "#00ff00", glitch = "#ff0055" }
+
+  local function get_color(key)
+    return phase_colors[key] or defaults[key]
+  end
+
+  -- Find current preset index (if any)
+  local current_preset_idx = nil
+  for i, preset in ipairs(phase_color_presets) do
+    if get_color("chaos") == preset.chaos and
+       get_color("revealing") == preset.revealing and
+       get_color("revealed") == preset.revealed and
+       get_color("cursor") == preset.cursor and
+       get_color("glitch") == preset.glitch then
+      current_preset_idx = i
+      break
+    end
+  end
+  local preset_label = current_preset_idx and phase_color_presets[current_preset_idx].name or "Custom"
+
+  return {
+    "",
+    "  Phase Highlight Colors",
+    "  " .. string.rep("─", 38),
+    "",
+    string.format("  [P] Preset:    %-12s ◀ ▶", preset_label),
+    "",
+    string.format("  [1] Chaos:     %s  ██", get_color("chaos")),
+    string.format("  [2] Revealing: %s  ██", get_color("revealing")),
+    string.format("  [3] Revealed:  %s  ██", get_color("revealed")),
+    string.format("  [4] Cursor:    %s  ██", get_color("cursor")),
+    string.format("  [5] Glitch:    %s  ██", get_color("glitch")),
+    "",
+    "  Keys:",
+    "    P: cycle preset",
+    "    1-5: edit color (hex input)",
+    "    r: reset to defaults",
+    "    Backspace: back",
+    "",
+  }
+end
+
 -- All available styles
 local ALL_STYLES = { "blocks", "gradient", "isometric", "box", "minimal", "pixel", "braille" }
 
@@ -901,6 +957,8 @@ local function update_settings_content()
       lines = get_messages_submenu_lines()
     elseif settings_state.submenu == "footer" then
       lines = get_footer_submenu_lines()
+    elseif settings_state.submenu == "phase_colors" then
+      lines = get_phase_colors_submenu_lines()
     else
       lines = get_effect_submenu_lines(settings_state.submenu)
     end
@@ -967,6 +1025,8 @@ local function update_settings_content()
       string.format("  [s] Steps:    %d", opts.animation.steps),
       string.format("  [c] Charset:  %-10s ◀ %d/%d ▶", char_preset, charset_idx, #config.char_preset_names),
       charset_warning,
+      string.format("  [p] Phase HL: %s", opts.animation.use_phase_highlights and "ON " or "OFF"),
+      opts.animation.use_phase_highlights and "  [P] Phase Colors..." or "",
       "  [t] Timing...",
       "",
       "  Content",
@@ -1695,6 +1755,20 @@ local function setup_settings_keybindings(buf)
       adjust_glitch_resolve_speed(0.1)
     elseif settings_state.submenu == "spiral" then
       cycle_spiral_rotation(1)
+    elseif settings_state.submenu == "phase_colors" then
+      -- Reset phase colors to defaults
+      config.options.animation.phase_colors = {
+        chaos = nil,
+        revealing = nil,
+        revealed = nil,
+        cursor = nil,
+        glitch = nil,
+      }
+      config.save()
+      animation.refresh_phase_highlights()
+      update_settings_content()
+      replay_preview()
+      vim.notify("Phase colors reset to defaults", vim.log.levels.INFO)
     end
   end, { buffer = buf, nowait = true, silent = true })
 
@@ -1954,6 +2028,50 @@ local function setup_settings_keybindings(buf)
     end
   end, { buffer = buf, nowait = true, silent = true })
 
+  -- Phase colors submenu (P key - opens submenu or cycles preset)
+  vim.keymap.set("n", "P", function()
+    if not settings_state.submenu then
+      -- Open phase colors submenu (only if phase HL is enabled)
+      if config.options.animation.use_phase_highlights then
+        settings_state.submenu = "phase_colors"
+        update_settings_content()
+      end
+    elseif settings_state.submenu == "phase_colors" then
+      -- Cycle through color presets
+      local phase_colors = config.options.animation.phase_colors or {}
+      local defaults = { chaos = "#555555", revealing = "#888888", revealed = "#ffffff", cursor = "#00ff00", glitch = "#ff0055" }
+      local function get_color(key)
+        return phase_colors[key] or defaults[key]
+      end
+      -- Find current preset
+      local current_idx = nil
+      for i, preset in ipairs(phase_color_presets) do
+        if get_color("chaos") == preset.chaos and
+           get_color("revealing") == preset.revealing and
+           get_color("revealed") == preset.revealed and
+           get_color("cursor") == preset.cursor and
+           get_color("glitch") == preset.glitch then
+          current_idx = i
+          break
+        end
+      end
+      -- Cycle to next preset
+      local next_idx = current_idx and (current_idx % #phase_color_presets) + 1 or 1
+      local preset = phase_color_presets[next_idx]
+      config.options.animation.phase_colors = {
+        chaos = preset.chaos,
+        revealing = preset.revealing,
+        revealed = preset.revealed,
+        cursor = preset.cursor,
+        glitch = preset.glitch,
+      }
+      config.save()
+      animation.refresh_phase_highlights()
+      update_settings_content()
+      replay_preview()
+    end
+  end, { buffer = buf, nowait = true, silent = true })
+
   -- Footer alignment cycling / Ambient cycling
   vim.keymap.set("n", "a", function()
     if settings_state.submenu == "footer" then
@@ -1999,7 +2117,7 @@ local function setup_settings_keybindings(buf)
     end
   end, { buffer = buf, nowait = true, silent = true })
 
-  -- Message preview (show full message in notification)
+  -- Message preview (show full message in notification) / Phase highlights toggle
   vim.keymap.set("n", "p", function()
     if settings_state.submenu == "messages" then
       local msg = message_browser.filtered[message_browser.index]
@@ -2010,6 +2128,11 @@ local function setup_settings_keybindings(buf)
       else
         vim.notify("No message selected", vim.log.levels.WARN)
       end
+    elseif not settings_state.submenu then
+      config.options.animation.use_phase_highlights = not config.options.animation.use_phase_highlights
+      config.save()
+      update_settings_content()
+      replay_preview()
     end
   end, { buffer = buf, nowait = true, silent = true })
 
@@ -2031,6 +2154,9 @@ local function setup_settings_keybindings(buf)
     end
   end, { buffer = buf, nowait = true, silent = true })
 
+  -- Phase color keys mapping
+  local phase_color_keys = { "chaos", "revealing", "revealed", "cursor", "glitch" }
+
   for i = 1, 9 do
     vim.keymap.set("n", tostring(i), function()
       if settings_state.submenu == "styles" then
@@ -2043,6 +2169,27 @@ local function setup_settings_keybindings(buf)
             settings_state.current_art = arts[math.random(1, #arts)]
             replay_preview()
           end
+        end
+      elseif settings_state.submenu == "phase_colors" then
+        -- 1-5 edit individual phase colors
+        if i <= 5 then
+          local key = phase_color_keys[i]
+          local current = config.options.animation.phase_colors[key]
+          local defaults = { chaos = "#555555", revealing = "#888888", revealed = "#ffffff", cursor = "#00ff00", glitch = "#ff0055" }
+          vim.ui.input({
+            prompt = string.format("%s color (hex): ", key:sub(1,1):upper() .. key:sub(2)),
+            default = current or defaults[key],
+          }, function(input)
+            if input and input:match("^#%x%x%x%x%x%x$") then
+              config.options.animation.phase_colors[key] = input
+              config.save()
+              animation.refresh_phase_highlights()
+              update_settings_content()
+              replay_preview()
+            elseif input then
+              vim.notify("Invalid hex color. Use format: #rrggbb", vim.log.levels.WARN)
+            end
+          end)
         end
       elseif settings_state.submenu == "messages" then
         if message_browser.view == "themes" then

--- a/lua/ascii-animation/config.lua
+++ b/lua/ascii-animation/config.lua
@@ -83,6 +83,16 @@ M.defaults = {
     ambient_interval = 2000, -- How often ambient effect triggers (ms)
     -- Character set preset for chaos/scramble effects
     char_preset = "default", -- "default" | "minimal" | "matrix" | "blocks" | "braille" | "stars" | "geometric" | "binary" | "dots"
+    -- Phase-based highlighting (uses AsciiAnimation* highlight groups)
+    use_phase_highlights = false,
+    -- Custom colors for phase highlights (nil = use defaults)
+    phase_colors = {
+      chaos = nil,      -- Default: #555555
+      revealing = nil,  -- Default: #888888
+      revealed = nil,   -- Default: #ffffff
+      cursor = nil,     -- Default: #00ff00
+      glitch = nil,     -- Default: #ff0055
+    },
     -- Terminal width handling
     auto_fit = false,       -- Skip arts wider than terminal
     min_width = 60,         -- Minimum terminal width for animation
@@ -214,6 +224,8 @@ function M.save()
       max_delay = M.options.animation.max_delay,
       ambient_interval = M.options.animation.ambient_interval,
       char_preset = M.options.animation.char_preset,
+      use_phase_highlights = M.options.animation.use_phase_highlights,
+      phase_colors = M.options.animation.phase_colors,
     },
     selection = {
       random_mode = M.options.selection.random_mode,
@@ -265,6 +277,8 @@ function M.clear_saved()
   M.options.animation.max_delay = M.defaults.animation.max_delay
   M.options.animation.ambient_interval = M.defaults.animation.ambient_interval
   M.options.animation.char_preset = M.defaults.animation.char_preset
+  M.options.animation.use_phase_highlights = M.defaults.animation.use_phase_highlights
+  M.options.animation.phase_colors = vim.deepcopy(M.defaults.animation.phase_colors)
   -- Reset content settings
   M.options.content.styles = M.defaults.content.styles
   -- Reset message settings


### PR DESCRIPTION
## Summary
- Add phase-based highlighting with 5 customizable highlight groups
- New `use_phase_highlights` config option (default: false for backwards compat)
- Phase Colors submenu in `:AsciiSettings` with 6 color presets
- Individual hex color editing for each phase

## Highlight Groups
| Group | Default | Description |
|-------|---------|-------------|
| `AsciiAnimationChaos` | #555555 | Unrevealed chaos characters |
| `AsciiAnimationRevealing` | #888888 | Characters about to reveal |
| `AsciiAnimationRevealed` | #ffffff | Fully revealed characters |
| `AsciiAnimationCursor` | #00ff00 | Typewriter cursor |
| `AsciiAnimationGlitch` | #ff0055 | Glitch effect corruption |

## Color Presets
Default, Cyberpunk, Ocean, Sunset, Forest, Monochrome

## Test plan
- [ ] Enable phase highlights with `p` in `:AsciiSettings`
- [ ] Open Phase Colors with `P`, cycle presets
- [ ] Edit individual colors with `1`-`5`
- [ ] Verify colors persist across sessions
- [ ] Test all animation effects with phase highlights

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)