### PR TITLE
feat: add message_categories and exclude_categories config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,10 @@ require("ascii-animation").setup({
 
     -- Message no-repeat: avoid showing the same message repeatedly
     message_no_repeat = 5,        -- Don't repeat any of the last 5 messages
+
+    -- Message category filtering
+    message_categories = nil,     -- Include-list: only these themes (e.g. {"zen", "witty"})
+    exclude_categories = nil,     -- Exclude-list: disable these themes (e.g. {"cryptic"})
   },
 
   -- Footer settings
@@ -826,6 +830,8 @@ animation = {
 | `content.favorite_weight` | number | `2` | Multiplier for favorites in selection pool |
 | `content.no_repeat` | boolean/number | `false` | Don't repeat last N arts: `false`, `true` (1), or number |
 | `content.message_no_repeat` | boolean/number | `false` | Don't repeat last N messages: `false`, `true` (1), or number |
+| `content.message_categories` | table/nil | `nil` | Include-list: only show messages from these theme categories (e.g. `{"zen", "witty"}`) |
+| `content.exclude_categories` | table/nil | `nil` | Exclude-list: hide messages from these theme categories (e.g. `{"cryptic"}`) |
 
 Message favorites and disabled states are managed via `:AsciiSettings` → `g` (Message Browser) and persist automatically.
 

--- a/lua/ascii-animation/config.lua
+++ b/lua/ascii-animation/config.lua
@@ -418,6 +418,12 @@ M.defaults = {
     -- number N: Don't repeat any of the last N shown messages
     message_no_repeat = false,
 
+    -- Message category filtering (by theme name)
+    -- Include-list: only these theme categories (nil = all)
+    message_categories = nil,
+    -- Exclude-list: disable these theme categories (nil = none)
+    exclude_categories = nil,
+
   },
 
   -- Footer settings
@@ -555,6 +561,20 @@ function M.clear_saved()
   M.message_favorites = {}
   M.message_disabled = {}
   M.themes_disabled = {}
+  -- Re-apply config-based category filtering
+  local content_opts = M.options.content or {}
+  if content_opts.message_categories then
+    local include = {}
+    for _, cat in ipairs(content_opts.message_categories) do include[cat] = true end
+    local taglines = require("ascii-animation.content.messages.taglines")
+    for _, theme in ipairs(taglines.themes) do
+      if not include[theme] then table.insert(M.themes_disabled, theme) end
+    end
+  elseif content_opts.exclude_categories then
+    for _, cat in ipairs(content_opts.exclude_categories) do
+      table.insert(M.themes_disabled, cat)
+    end
+  end
   -- Reset footer settings
   M.options.footer.enabled = M.defaults.footer.enabled
   M.options.footer.template = M.defaults.footer.template
@@ -679,6 +699,21 @@ function M.setup(opts)
   end
   if saved.themes_disabled then
     M.themes_disabled = saved.themes_disabled
+  else
+    -- Apply config-based category filtering when no saved UI prefs exist
+    local content_opts = M.options.content or {}
+    if content_opts.message_categories then
+      local include = {}
+      for _, cat in ipairs(content_opts.message_categories) do include[cat] = true end
+      local taglines = require("ascii-animation.content.messages.taglines")
+      for _, theme in ipairs(taglines.themes) do
+        if not include[theme] then table.insert(M.themes_disabled, theme) end
+      end
+    elseif content_opts.exclude_categories then
+      for _, cat in ipairs(content_opts.exclude_categories) do
+        table.insert(M.themes_disabled, cat)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
## Summary
- Add `message_categories` (include-list) and `exclude_categories` (exclude-list) to `setup()` content options, allowing users to pre-filter message themes from their config file
- Translate config options into `themes_disabled` entries at startup; saved UI prefs take priority
- Re-apply config-based filtering on reset (`R` in `:AsciiSettings`)
- Document new options in README config example and reference table

Closes #38

## Test plan
- [ ] `setup({ content = { message_categories = { "zen", "witty" } } })` → only zen/witty messages appear
- [ ] `setup({ content = { exclude_categories = { "cryptic" } } })` → all except cryptic
- [ ] Toggle themes in `:AsciiSettings`, reopen → saved prefs override config
- [ ] Press `R` to reset → re-applies config-based filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)