### PR TITLE
feat: add reduced motion mode

### DIFF
--- a/lua/ascii-animation/animation.lua
+++ b/lua/ascii-animation/animation.lua
@@ -1607,6 +1607,13 @@ function M.start(buf, header_lines, highlight)
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
   local header_end = find_header_end(lines, header_lines)
 
+  -- Reduced motion: skip animation, show final art immediately
+  if config.options.animation.reduced_motion then
+    setup_color_mode_highlights(header_end)
+    start_ambient(buf, header_end, highlight)
+    return
+  end
+
   -- Resolve effect (pick random if "random")
   local effect = config.options.animation.effect
   if effect == "random" then

--- a/lua/ascii-animation/commands.lua
+++ b/lua/ascii-animation/commands.lua
@@ -1118,6 +1118,7 @@ local function update_settings_content()
       opts_hint,
       string.format("  [a] Ambient:  %-10s ◀ %d/%d ▶", opts.animation.ambient, ambient_idx, #ambients),
       string.format("  [l] Loop:     %s", opts.animation.loop and "ON " or "OFF"),
+      string.format("  [r] Reduced motion: %s", opts.animation.reduced_motion and "ON " or "OFF"),
       string.format("  [s] Steps:    %d", opts.animation.steps),
       string.format("  [c] Charset:  %-10s ◀ %d/%d ▶", char_preset, charset_idx, #config.char_preset_names),
       charset_warning,
@@ -1211,6 +1212,14 @@ end
 -- Toggle loop
 local function toggle_loop()
   config.options.animation.loop = not config.options.animation.loop
+  config.save()
+  update_settings_content()
+  replay_preview()
+end
+
+-- Toggle reduced motion
+local function toggle_reduced_motion()
+  config.options.animation.reduced_motion = not config.options.animation.reduced_motion
   config.save()
   update_settings_content()
   replay_preview()
@@ -1907,7 +1916,9 @@ local function setup_settings_keybindings(buf)
   end, { buffer = buf, nowait = true, silent = true })
 
   vim.keymap.set("n", "r", function()
-    if settings_state.submenu == "glitch" then
+    if not settings_state.submenu then
+      toggle_reduced_motion()
+    elseif settings_state.submenu == "glitch" then
       adjust_glitch_resolve_speed(0.1)
     elseif settings_state.submenu == "spiral" then
       cycle_spiral_rotation(1)

--- a/lua/ascii-animation/config.lua
+++ b/lua/ascii-animation/config.lua
@@ -342,6 +342,8 @@ M.defaults = {
     -- Period-based color schemes (auto-changes phase colors by time of day)
     period_colors = false,          -- Enable period-based colors
     period_color_overrides = {},    -- Override specific period colors: { morning = { revealed = "#ff6600" } }
+    -- Reduced motion: skip animation, show final art immediately
+    reduced_motion = false,
   },
 
   -- Content selection settings
@@ -492,6 +494,7 @@ function M.save()
       gradient = M.options.animation.gradient,
       period_colors = M.options.animation.period_colors,
       period_color_overrides = M.options.animation.period_color_overrides,
+      reduced_motion = M.options.animation.reduced_motion,
     },
     selection = {
       random_mode = M.options.selection.random_mode,
@@ -554,6 +557,7 @@ function M.clear_saved()
   M.options.animation.gradient = vim.deepcopy(M.defaults.animation.gradient)
   M.options.animation.period_colors = M.defaults.animation.period_colors
   M.options.animation.period_color_overrides = vim.deepcopy(M.defaults.animation.period_color_overrides)
+  M.options.animation.reduced_motion = M.defaults.animation.reduced_motion
   -- Reset content settings
   M.options.content.styles = M.defaults.content.styles
   M.options.content.message_no_repeat = M.defaults.content.message_no_repeat


### PR DESCRIPTION
## Summary
- Add `reduced_motion` config option that skips animation and shows final ASCII art immediately
- Toggle via `[r]` key in `:AsciiSettings` main menu, persists across sessions
- Ambient effects still work when reduced motion is enabled

Closes #61

## Test plan
- [ ] `:AsciiSettings` → press `r` → toggles "Reduced motion: ON/OFF"
- [ ] With reduced motion ON: reopen Neovim → ASCII art appears instantly
- [ ] Ambient effects still work when reduced motion is ON
- [ ] With reduced motion OFF: animation plays normally (no regression)
- [ ] Setting persists across sessions
- [ ] `r` key still works in glitch/spiral/phase_colors/color_mode submenus

🤖 Generated with [Claude Code](https://claude.com/claude-code)