### PR TITLE
feat: add animation control commands

### DIFF
--- a/lua/ascii-animation/commands.lua
+++ b/lua/ascii-animation/commands.lua
@@ -1,5 +1,6 @@
 -- User commands for ascii-animation
--- Provides :AsciiPreview, :AsciiList, :AsciiSettings, :AsciiRefresh, :AsciiStop, :AsciiRestart, :AsciiCharset
+-- Provides :AsciiPreview, :AsciiList, :AsciiSettings, :AsciiRefresh, :AsciiStop, :AsciiRestart, :AsciiCharset,
+-- :AsciiPause, :AsciiResume, :AsciiNext, :AsciiEffect
 
 local config = require("ascii-animation.config")
 local animation = require("ascii-animation.animation")
@@ -2690,6 +2691,55 @@ function M.register_commands()
       return matches
     end,
     desc = "Set character set preset for animation",
+  })
+
+  vim.api.nvim_create_user_command("AsciiPause", function()
+    if animation.pause() then
+      vim.notify("Animation paused", vim.log.levels.INFO)
+    else
+      vim.notify("No animation to pause", vim.log.levels.WARN)
+    end
+  end, { desc = "Pause current ASCII animation" })
+
+  vim.api.nvim_create_user_command("AsciiResume", function()
+    if animation.resume() then
+      vim.notify("Animation resumed", vim.log.levels.INFO)
+    else
+      vim.notify("No paused animation to resume", vim.log.levels.WARN)
+    end
+  end, { desc = "Resume paused ASCII animation" })
+
+  vim.api.nvim_create_user_command("AsciiNext", function()
+    local effect = animation.next_effect()
+    if effect then
+      vim.notify("Effect: " .. effect, vim.log.levels.INFO)
+    end
+  end, { desc = "Switch to next animation effect" })
+
+  vim.api.nvim_create_user_command("AsciiEffect", function(opts)
+    local name = opts.args
+    if name == "" then
+      vim.notify("Current effect: " .. (config.options.animation.effect or "chaos"), vim.log.levels.INFO)
+      return
+    end
+    if animation.set_effect(name) then
+      vim.notify("Effect set to: " .. name, vim.log.levels.INFO)
+    else
+      vim.notify("Invalid effect. Valid: chaos, typewriter, diagonal, lines, matrix, wave, fade, scramble, rain, spiral, explode, implode, glitch, random", vim.log.levels.WARN)
+    end
+  end, {
+    nargs = "?",
+    complete = function(arg_lead)
+      local valid_effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "scramble", "rain", "spiral", "explode", "implode", "glitch", "random" }
+      local matches = {}
+      for _, name in ipairs(valid_effects) do
+        if name:find(arg_lead, 1, true) then
+          table.insert(matches, name)
+        end
+      end
+      return matches
+    end,
+    desc = "Set animation effect",
   })
 end
 

--- a/lua/ascii-animation/init.lua
+++ b/lua/ascii-animation/init.lua
@@ -320,6 +320,26 @@ function M.stop()
   animation.stop()
 end
 
+-- Pause current animation
+function M.pause()
+  animation.pause()
+end
+
+-- Resume paused animation
+function M.resume()
+  animation.resume()
+end
+
+-- Cycle to the next animation effect
+function M.next_effect()
+  return animation.next_effect()
+end
+
+-- Set a specific animation effect by name
+function M.set_effect(name)
+  return animation.set_effect(name)
+end
+
 -- Expose commands module
 M.commands = commands
 


### PR DESCRIPTION
## Summary
- Add `:AsciiPause` / `:AsciiResume` to pause and resume animation mid-playback
- Add `:AsciiNext` to cycle through effects and `:AsciiEffect <name>` to set a specific effect (with tab completion)
- Expose `pause()`, `resume()`, `next_effect()`, `set_effect(name)` in the public Lua API

Closes #62

## Test plan
- [ ] `:AsciiPause` while animation is running → freezes at current frame
- [ ] `:AsciiResume` → continues from paused position
- [ ] `:AsciiPause` with no animation → shows warning
- [ ] `:AsciiNext` → cycles to next effect, restarts, persists setting
- [ ] `:AsciiEffect wave` → sets wave effect, restarts, persists
- [ ] `:AsciiEffect` (no arg) → shows current effect
- [ ] `:AsciiEffect invalid` → shows error with valid options
- [ ] `:AsciiEffect <Tab>` → completes all 14 effect names
- [ ] Lua API: `require("ascii-animation").pause()` etc. all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)