### PR TITLE
feat: art import from .txt files (#63)

### DIFF
--- a/lua/ascii-animation/config.lua
+++ b/lua/ascii-animation/config.lua
@@ -374,6 +374,7 @@ M.defaults = {
 
     -- User additions (merged with built-in)
     custom_arts = {},            -- User-defined arts by period
+    custom_arts_dir = nil,       -- Directory path to load .txt art files from
     custom_messages = {},        -- User-defined messages by period
 
     -- Personalization placeholders


### PR DESCRIPTION
## Summary
- Add `custom_arts_dir` config option to load ASCII art from `.txt` files
- Support optional metadata headers (`# name:`, `# period:`, `# style:`) in art files
- Support period subdirectories (`morning/`, `night/`, etc.) for time-based art
- Integrate dir arts into all lookup functions (get_art_for_period, list_arts, list_arts_for_period, get_art_by_id)

Closes #63

## Test plan
- [x] No `custom_arts_dir` configured — no change in behavior, no errors
- [x] `.txt` file without metadata — uses filename as name, available for all periods
- [x] `.txt` file with metadata header — parsed correctly with name/period/style
- [x] Subdirectory `morning/sunrise.txt` — loaded as morning period art
- [x] `:AsciiPreview custom_hello` — shows imported art
- [x] Custom arts appear in `:AsciiSettings` browsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)