### PR TITLE
feat: add theme presets (#65)

### DIFF
--- a/lua/ascii-animation/init.lua
+++ b/lua/ascii-animation/init.lua
@@ -340,6 +340,20 @@ function M.set_effect(name)
   return animation.set_effect(name)
 end
 
+-- Apply a named theme preset
+function M.apply_preset(name)
+  return config.apply_preset(name)
+end
+
+-- List all available theme preset names
+function M.list_presets()
+  local names = vim.deepcopy(config.theme_preset_names)
+  for k in pairs(config.options.content.custom_presets or {}) do
+    table.insert(names, k)
+  end
+  return names
+end
+
 -- Expose commands module
 M.commands = commands
 


### PR DESCRIPTION
## Summary
- Add 5 built-in theme presets (retro, zen, cyberpunk, cinematic, hacker) that bundle style, effect, ambient, charset, and color theme into a single setting
- Add `:AsciiPreset` command with tab completion to apply/query presets
- Add `[T]` cycling in `:AsciiSettings` main menu
- Support user-defined `custom_presets` in config
- Presets persist across sessions and reset with `[R]`

## Test plan
- [x] `:AsciiPreset retro` applies correct settings
- [x] `:AsciiPreset` (no args) shows current preset
- [x] `:AsciiPreset invalid` shows error with valid names
- [x] Tab completion lists all presets
- [x] `[T]` in `:AsciiSettings` cycles through presets
- [x] `[R]` reset clears active preset

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)