### PR TITLE
feat: add audio-reactive display modes (rain, shatter, fireworks, heartbeat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Cinematic text animation for Neovim dashboards. Watch your ASCII art materialize
 - **Phase-based highlighting**: Customize colors for chaos, revealing, and revealed states
 - **Period-based color schemes**: Automatic warm/cool colors based on time of day
 - **Theme presets**: Apply bundled settings (retro, zen, cyberpunk, cinematic, hacker) with a single command
-- **Screensaver**: Full-screen animated ASCII art after idle timeout with 6 display modes (static, bounce, tile, marquee, zoom, random)
+- **Screensaver**: Full-screen animated ASCII art after idle timeout with 13 display modes (static, bounce, tile, marquee, zoom, pulse, waves, rain, shatter, fireworks, heartbeat, random)
 - **Holiday content**: Auto-detected holiday-themed ASCII art and messages with higher selection priority (5 built-in holidays, user-extensible)
 - **User commands**: `:AsciiPreview`, `:AsciiSettings`, `:AsciiRefresh`, `:AsciiStop`, `:AsciiRestart`, `:AsciiCharset`, `:AsciiPause`, `:AsciiResume`, `:AsciiNext`, `:AsciiEffect`, `:AsciiPreset`, `:AsciiScreensaver`
 
@@ -753,8 +753,9 @@ screensaver = {
   enabled = true,
   timeout = 1000 * 60 * 5,  -- 5 minutes
   effect = "random",
-  display = "bounce",        -- static, bounce, tile, marquee, zoom, random
+  display = "bounce",        -- static, bounce, tile, marquee, zoom, pulse, waves, rain, shatter, fireworks, heartbeat, random
   dismiss = "any",
+  audio_reactive = false,    -- pulse with sound (requires sox)
 }
 ```
 
@@ -767,7 +768,17 @@ screensaver = {
 | `tile` | Art repeats in a grid pattern filling the screen |
 | `marquee` | Art reveals once, then scrolls horizontally |
 | `zoom` | Art displayed at 2x size with looping animation |
-| `random` | Randomly picks one of the above modes |
+| `pulse` | Art scales between 1x-2x based on microphone audio level (requires sox) |
+| `waves` | Concentric ripples radiate from art edges on sound (requires sox) |
+| `rain` | Characters fall from top like rain, heavier with louder sound (requires sox) |
+| `shatter` | Art explodes on sound spikes, reassembles in silence (requires sox) |
+| `fireworks` | Burst explosions around art triggered by sound (requires sox) |
+| `heartbeat` | Glowing aura pulses around art edges on beats (requires sox) |
+| `random` | Randomly picks a mode (includes audio modes if sox available) |
+
+**Audio-Reactive Mode:**
+
+Enable `audio_reactive` to make the screensaver pulse with sound. Louder audio increases bounce/marquee movement speed and shortens loop delays for static/tile/zoom modes. Audio-driven display modes (`pulse`, `waves`, `rain`, `shatter`, `fireworks`, `heartbeat`) auto-start audio sampling and react to sound in unique ways. Requires [sox](https://sox.sourceforge.net/) (`rec` command) for microphone input — install with `brew install sox` (macOS) or `apt install sox` (Linux). Toggle via `:AsciiSettings` → `V` → `[a]`.
 
 ### `:checkhealth ascii-animation`
 
@@ -964,8 +975,9 @@ Message favorites and disabled states are managed via `:AsciiSettings` → `g` (
 | `screensaver.enabled` | boolean | `false` | Enable idle screensaver (opt-in) |
 | `screensaver.timeout` | number | `300000` | Idle timeout in ms (default: 5 minutes) |
 | `screensaver.effect` | string | `"random"` | Animation effect for reveal: any effect name or `"random"` |
-| `screensaver.display` | string | `"static"` | Display mode: `"static"`, `"bounce"`, `"tile"`, `"marquee"`, `"zoom"`, `"random"` |
+| `screensaver.display` | string | `"static"` | Display mode: `"static"`, `"bounce"`, `"tile"`, `"marquee"`, `"zoom"`, `"pulse"`, `"waves"`, `"rain"`, `"shatter"`, `"fireworks"`, `"heartbeat"`, `"random"` |
 | `screensaver.dismiss` | string | `"any"` | Dismiss trigger: `"any"` key or `"escape"` only |
+| `screensaver.audio_reactive` | boolean | `false` | Pulse animation based on microphone input (requires sox) |
 
 ### Holiday Options
 

--- a/lua/ascii-animation/audio.lua
+++ b/lua/ascii-animation/audio.lua
@@ -1,0 +1,105 @@
+-- Audio level sampling for audio-reactive screensaver mode
+-- Uses sox (rec) to sample microphone input levels
+
+local M = {}
+
+local state = {
+  timer = nil,                   -- vim.uv.new_timer() for periodic sampling
+  level = 0.0,                   -- Smoothed audio level (0.0-1.0)
+  running = false,
+  sox_available = nil,           -- Cached sox check (nil = unchecked)
+  sampling_in_progress = false,  -- Guard against overlapping async calls
+}
+
+-- Check if sox (rec) is available on the system
+function M.check_sox()
+  if state.sox_available == nil then
+    state.sox_available = vim.fn.executable("rec") == 1
+  end
+  return state.sox_available
+end
+
+-- Start audio level sampling
+-- opts: { interval = ms, smoothing = 0.0-1.0 }
+function M.start(opts)
+  if state.running then
+    return true
+  end
+
+  if not M.check_sox() then
+    vim.notify("Audio-reactive mode requires sox. Install: brew install sox / apt install sox", vim.log.levels.WARN)
+    return false
+  end
+
+  opts = opts or {}
+  local interval = opts.interval or 100
+  local smoothing = opts.smoothing or 0.3
+
+  state.timer = vim.uv.new_timer()
+  state.running = true
+  state.level = 0.0
+
+  state.timer:start(interval, interval, vim.schedule_wrap(function()
+    if not state.running then
+      return
+    end
+
+    -- Prevent overlapping async calls
+    if state.sampling_in_progress then
+      return
+    end
+    state.sampling_in_progress = true
+
+    local cmd = { "rec", "-n", "trim", "0", "0.1", "stat" }
+    vim.system(cmd, { text = true }, vim.schedule_wrap(function(result)
+      state.sampling_in_progress = false
+
+      if not state.running then
+        return
+      end
+
+      -- Parse RMS amplitude from sox stat output (sent to stderr)
+      local raw = 0.0
+      if result and result.stderr then
+        local rms = result.stderr:match("RMS%s+amplitude:%s+([%d%.]+)")
+        if rms then
+          raw = tonumber(rms) or 0.0
+          -- Clamp to 0.0-1.0
+          if raw > 1.0 then raw = 1.0 end
+          if raw < 0.0 then raw = 0.0 end
+        end
+      end
+
+      -- Exponential moving average for smoothing
+      state.level = smoothing * raw + (1 - smoothing) * state.level
+    end))
+  end))
+
+  return true
+end
+
+-- Stop audio level sampling
+function M.stop()
+  state.running = false
+
+  if state.timer then
+    state.timer:stop()
+    state.timer:close()
+    state.timer = nil
+  end
+
+  state.level = 0.0
+  state.sampling_in_progress = false
+end
+
+-- Get current smoothed audio level (always safe to call)
+function M.get_level()
+  return state.level
+end
+
+-- Check if audio sampling is running
+function M.is_running()
+  return state.running
+end
+
+return M

--- a/lua/ascii-animation/commands.lua
+++ b/lua/ascii-animation/commands.lua
@@ -1072,6 +1072,7 @@ local function get_screensaver_submenu_lines()
     string.format("  [f] Effect:   %-10s ◀ %d/%d ▶", ss_effect, effect_idx, #effects),
     string.format("  [m] Display:  %-10s ◀ %d/%d ▶", display, display_idx, #display_names),
     string.format("  [d] Dismiss:  %-10s ◀ %d/%d ▶", dismiss, dismiss_idx, #dismiss_modes),
+    string.format("  [a] Audio:    %s", ss_opts.audio_reactive and "ON " or "OFF"),
     "",
     "  [Space] Test  Backspace: back",
     "",
@@ -2537,7 +2538,11 @@ local function setup_settings_keybindings(buf)
 
   -- Footer alignment cycling / Ambient cycling
   vim.keymap.set("n", "a", function()
-    if settings_state.submenu == "footer" then
+    if settings_state.submenu == "screensaver" then
+      config.options.screensaver.audio_reactive = not config.options.screensaver.audio_reactive
+      config.save()
+      update_settings_content()
+    elseif settings_state.submenu == "footer" then
       local alignments = { "left", "center", "right" }
       local current = config.options.footer.alignment or "center"
       local idx = 1

--- a/lua/ascii-animation/config.lua
+++ b/lua/ascii-animation/config.lua
@@ -61,7 +61,7 @@ M.theme_presets = {
 M.theme_preset_names = { "retro", "zen", "cyberpunk", "cinematic", "hacker" }
 
 -- Screensaver display mode names for cycling
-M.screensaver_display_names = { "static", "bounce", "tile", "marquee", "zoom", "random" }
+M.screensaver_display_names = { "static", "bounce", "tile", "marquee", "zoom", "pulse", "waves", "rain", "shatter", "fireworks", "heartbeat", "random" }
 
 -- Period-based color schemes for phase highlights
 M.period_color_schemes = {
@@ -494,7 +494,8 @@ M.defaults = {
     timeout = 1000 * 60 * 5,  -- Idle timeout in ms (default: 5 minutes)
     effect = "random",        -- Animation effect or "random"
     dismiss = "any",          -- "any" key or "escape" only
-    display = "static",       -- Display mode: "static" | "bounce" | "tile" | "marquee" | "zoom" | "random"
+    display = "static",       -- Display mode: "static" | "bounce" | "tile" | "marquee" | "zoom" | "pulse" | "random"
+    audio_reactive = false,   -- Enable audio-reactive mode (requires sox)
   },
 }
 
@@ -582,6 +583,7 @@ function M.save()
       effect = M.options.screensaver.effect,
       dismiss = M.options.screensaver.dismiss,
       display = M.options.screensaver.display,
+      audio_reactive = M.options.screensaver.audio_reactive,
     },
     favorites = M.favorites,
     favorites_weight = M.favorites_weight,

--- a/lua/ascii-animation/health.lua
+++ b/lua/ascii-animation/health.lua
@@ -119,6 +119,13 @@ local function check_terminal()
     vim.health.warn(string.format("Encoding is '%s'. UTF-8 recommended for special characters", encoding))
   end
 
+  -- Check sox for audio-reactive screensaver
+  if vim.fn.executable("rec") == 1 then
+    vim.health.ok("sox (rec) available for audio-reactive screensaver")
+  else
+    vim.health.info("sox (rec) not found — audio-reactive screensaver unavailable. Install: brew install sox / apt install sox")
+  end
+
   return true
 end
 

--- a/lua/ascii-animation/screensaver.lua
+++ b/lua/ascii-animation/screensaver.lua
@@ -3,6 +3,7 @@
 local config = require("ascii-animation.config")
 local animation = require("ascii-animation.animation")
 local content = require("ascii-animation.content")
+local audio = require("ascii-animation.audio")
 
 local M = {}
 
@@ -22,6 +23,9 @@ local state = {
   screen_width = nil,
   screen_height = nil,
   display_mode = nil,
+  audio_modulator = nil,
+  original_loop_delay = nil,
+  original_ambient_interval = nil,
 }
 
 -- Reset idle timer on activity
@@ -72,6 +76,9 @@ local function resolve_display_mode()
   local display = ss_opts.display or "static"
   if display == "random" then
     local modes = { "static", "bounce", "tile", "marquee", "zoom" }
+    if audio.check_sox() then
+      modes = { "static", "bounce", "tile", "marquee", "zoom", "pulse", "waves", "rain", "shatter", "fireworks", "heartbeat" }
+    end
     return modes[math.random(1, #modes)]
   end
   return display
@@ -234,9 +241,15 @@ local function start_bounce(buf, art_lines, w, h)
       return
     end
 
+    -- Audio-reactive speed multiplier
+    local move_mult = 1
+    if audio.is_running() then
+      move_mult = math.max(1, math.floor(1 + audio.get_level() * 3))
+    end
+
     -- Update position
-    pos_x = pos_x + vel_x
-    pos_y = pos_y + vel_y
+    pos_x = pos_x + vel_x * move_mult
+    pos_y = pos_y + vel_y * move_mult
 
     -- Bounce off edges
     if pos_x <= 0 then
@@ -292,8 +305,14 @@ local function start_marquee(buf, art_lines, w, h)
       return
     end
 
+    -- Audio-reactive speed multiplier
+    local scroll_speed = 1
+    if audio.is_running() then
+      scroll_speed = math.max(1, math.floor(1 + audio.get_level() * 3))
+    end
+
     -- Move left
-    pos_x = pos_x - 1
+    pos_x = pos_x - scroll_speed
 
     -- Wrap when fully off-screen left
     if pos_x + art_width < 0 then
@@ -326,6 +345,924 @@ local function build_centered_buffer(art_lines, w, h)
   end
 
   return lines, top_pad, art_height
+end
+
+-- Start pulse (audio-reactive equalizer chaos overlay) after animation completes
+local function start_pulse(buf, art_lines, w, h)
+  -- Auto-start audio if not already running
+  if not audio.is_running() then
+    if not audio.start() then
+      -- sox unavailable: art stays clean (no overlay)
+      return
+    end
+  end
+
+  local art_height = #art_lines
+  local top_pad = math.max(0, math.floor((h - art_height) / 2))
+
+  -- Cache chaos characters
+  local chaos_str = config.get_chaos_chars()
+  local chaos_tbl = vim.fn.split(chaos_str, "\\zs")
+  local function random_chaos()
+    return chaos_tbl[math.random(1, #chaos_tbl)]
+  end
+
+  local smoothed = 0.0
+  local ns_id = animation.ns_id
+
+  -- Stop any existing movement timer
+  if state.movement_timer then
+    state.movement_timer:stop()
+    state.movement_timer:close()
+    state.movement_timer = nil
+  end
+
+  state.movement_timer = vim.uv.new_timer()
+  state.movement_timer:start(80, 80, vim.schedule_wrap(function()
+    if not state.active or not buf or not vim.api.nvim_buf_is_valid(buf) then
+      if state.movement_timer then
+        state.movement_timer:stop()
+        state.movement_timer:close()
+        state.movement_timer = nil
+      end
+      return
+    end
+
+    -- Read audio level with 10x gain, clamped to 0-1
+    local raw = math.min(audio.get_level() * 10, 1.0)
+    -- Smooth to avoid jitter (0.4 blend factor)
+    smoothed = smoothed + (raw - smoothed) * 0.4
+
+    -- Clear previous overlays
+    pcall(vim.api.nvim_buf_clear_namespace, buf, ns_id, 0, -1)
+
+    -- Skip work when silent
+    if smoothed < 0.02 then return end
+
+    -- Overlay chaos on each art row, bottom-heavy like an equalizer
+    for i = 1, art_height do
+      local line = art_lines[i]
+      if line and #line > 0 then
+        local row_position = i / art_height -- 0=top, 1=bottom
+        local row_weight = row_position * row_position -- bottom-heavy curve
+        local zone_start = 1.0 - smoothed
+
+        if row_position >= zone_start then
+          local zone_depth = (row_position - zone_start) / smoothed
+          local disruption = zone_depth * row_weight * 0.85
+
+          local chars = vim.fn.split(line, "\\zs")
+          local modified = false
+          for j = 1, #chars do
+            if chars[j] ~= " " and math.random() < disruption then
+              chars[j] = random_chaos()
+              modified = true
+            end
+          end
+
+          if modified then
+            -- Pad to match centered position in buffer
+            local line_width = vim.fn.strdisplaywidth(line)
+            local left_pad = math.max(0, math.floor((w - line_width) / 2))
+            local overlay_text = string.rep(" ", left_pad) .. table.concat(chars)
+            local buf_row = top_pad + i - 1 -- 0-indexed buffer row
+            pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, buf_row, 0, {
+              virt_text = { { overlay_text, "Normal" } },
+              virt_text_pos = "overlay",
+              hl_mode = "combine",
+            })
+          end
+        end
+      end
+    end
+  end))
+end
+
+-- Start waves (audio-reactive concentric ripples from art edges) after animation completes
+local function start_waves(buf, art_lines, w, h)
+  -- Auto-start audio if not already running
+  if not audio.is_running() then
+    if not audio.start() then
+      -- sox unavailable: art stays clean (no ripples)
+      return
+    end
+  end
+
+  local art_height = #art_lines
+  local top_pad = math.max(0, math.floor((h - art_height) / 2))
+
+  -- Precompute art structure: chars and widths per line, and left padding
+  local art_chars = {}
+  local art_widths = {}
+  local art_left_pads = {}
+  for i, line in ipairs(art_lines) do
+    art_chars[i] = vim.fn.split(line, "\\zs")
+    local lw = vim.fn.strdisplaywidth(line)
+    art_widths[i] = lw
+    art_left_pads[i] = math.max(0, math.floor((w - lw) / 2))
+  end
+
+  -- Art bounding box in buffer coordinates (0-indexed)
+  local art_top = top_pad
+  local art_bottom = top_pad + art_height - 1
+  -- Use max art width for left/right bounds
+  local max_art_width = 0
+  for _, lw in ipairs(art_widths) do
+    if lw > max_art_width then max_art_width = lw end
+  end
+  local art_left = math.max(0, math.floor((w - max_art_width) / 2))
+  local art_right = art_left + max_art_width - 1
+
+  -- Cache chaos characters
+  local chaos_str = config.get_chaos_chars()
+  local chaos_tbl = vim.fn.split(chaos_str, "\\zs")
+  local function random_chaos()
+    return chaos_tbl[math.random(1, #chaos_tbl)]
+  end
+
+  local smoothed = 0.0
+  local prev_smoothed = 0.0
+  local ns_id = animation.ns_id
+  local waves = {}
+  local spawn_cooldown = 0
+
+  -- Stop any existing movement timer
+  if state.movement_timer then
+    state.movement_timer:stop()
+    state.movement_timer:close()
+    state.movement_timer = nil
+  end
+
+  state.movement_timer = vim.uv.new_timer()
+  state.movement_timer:start(80, 80, vim.schedule_wrap(function()
+    if not state.active or not buf or not vim.api.nvim_buf_is_valid(buf) then
+      if state.movement_timer then
+        state.movement_timer:stop()
+        state.movement_timer:close()
+        state.movement_timer = nil
+      end
+      return
+    end
+
+    -- Read audio level with 10x gain, clamped to 0-1
+    local raw = math.min(audio.get_level() * 10, 1.0)
+    prev_smoothed = smoothed
+    smoothed = smoothed + (raw - smoothed) * 0.4
+
+    -- Spawn new wave on audio spike
+    if spawn_cooldown > 0 then
+      spawn_cooldown = spawn_cooldown - 1
+    end
+    local delta = smoothed - prev_smoothed
+    if smoothed > 0.15 and delta > 0.05 and spawn_cooldown == 0 and #waves < 8 then
+      table.insert(waves, { radius = 0, intensity = math.min(smoothed * 1.5, 1.0), thickness = 3 })
+      spawn_cooldown = 3
+    end
+
+    -- Advance waves
+    local active_waves = {}
+    local max_dim = math.max(w, h)
+    for _, wave in ipairs(waves) do
+      wave.radius = wave.radius + 0.8
+      wave.intensity = wave.intensity * 0.92
+      if wave.intensity >= 0.05 and wave.radius < max_dim then
+        table.insert(active_waves, wave)
+      end
+    end
+    waves = active_waves
+
+    -- Clear previous overlays
+    pcall(vim.api.nvim_buf_clear_namespace, buf, ns_id, 0, -1)
+
+    -- Skip rendering when silent and no active waves
+    if smoothed < 0.02 and #waves == 0 then return end
+
+    -- Render waves
+    for row = 0, h - 1 do
+      local in_art_rows = (row >= art_top and row <= art_bottom)
+      local art_row_idx = row - art_top + 1 -- 1-indexed into art_lines
+
+      -- Compute Chebyshev distance to art bounding box for each column
+      local dy = 0
+      if row < art_top then
+        dy = art_top - row
+      elseif row > art_bottom then
+        dy = row - art_bottom
+      end
+
+      local overlay_chars = {}
+      local has_content = false
+
+      for col = 0, w - 1 do
+        local dx = 0
+        if col < art_left then
+          dx = art_left - col
+        elseif col > art_right then
+          dx = col - art_right
+        end
+
+        local distance = math.max(dx, dy)
+
+        -- Check if this cell is inside the art region
+        local in_art_region = in_art_rows and col >= art_left and col <= art_right
+
+        if in_art_region then
+          -- Preserve art character: reproduce from precomputed data
+          local line_left = art_left_pads[art_row_idx]
+          local local_col = col - line_left
+          local chars = art_chars[art_row_idx]
+          if local_col >= 0 and chars and local_col < #chars then
+            local ch = chars[local_col + 1]
+            if ch then
+              table.insert(overlay_chars, ch)
+            else
+              table.insert(overlay_chars, " ")
+            end
+          else
+            table.insert(overlay_chars, " ")
+          end
+        elseif distance > 0 then
+          -- Outside art: check if any wave covers this cell
+          local max_intensity = 0
+          for _, wave in ipairs(waves) do
+            if distance >= wave.radius and distance < wave.radius + wave.thickness then
+              -- Fade across band width (stronger at inner edge)
+              local band_pos = (distance - wave.radius) / wave.thickness
+              local cell_intensity = wave.intensity * (1 - band_pos)
+              if cell_intensity > max_intensity then
+                max_intensity = cell_intensity
+              end
+            end
+          end
+
+          if max_intensity > 0 and math.random() < max_intensity then
+            table.insert(overlay_chars, random_chaos())
+            has_content = true
+          else
+            table.insert(overlay_chars, " ")
+          end
+        else
+          table.insert(overlay_chars, " ")
+        end
+      end
+
+      if has_content or in_art_rows then
+        local overlay_text = table.concat(overlay_chars)
+        pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, row, 0, {
+          virt_text = { { overlay_text, "Normal" } },
+          virt_text_pos = "overlay",
+          hl_mode = "combine",
+        })
+      end
+    end
+  end))
+end
+
+-- Start rain (audio-reactive falling characters) after animation completes
+local function start_rain(buf, art_lines, w, h)
+  -- Auto-start audio if not already running
+  if not audio.is_running() then
+    if not audio.start() then
+      return
+    end
+  end
+
+  local art_height = #art_lines
+  local top_pad = math.max(0, math.floor((h - art_height) / 2))
+
+  -- Precompute art structure for reproduction
+  local art_chars = {}
+  local art_widths = {}
+  local art_left_pads = {}
+  for i, line in ipairs(art_lines) do
+    art_chars[i] = vim.fn.split(line, "\\zs")
+    local lw = vim.fn.strdisplaywidth(line)
+    art_widths[i] = lw
+    art_left_pads[i] = math.max(0, math.floor((w - lw) / 2))
+  end
+
+  -- Art bounding box in buffer coordinates (0-indexed)
+  local art_top = top_pad
+  local art_bottom = top_pad + art_height - 1
+  local max_art_width = 0
+  for _, lw in ipairs(art_widths) do
+    if lw > max_art_width then max_art_width = lw end
+  end
+  local art_left = math.max(0, math.floor((w - max_art_width) / 2))
+  local art_right = art_left + max_art_width - 1
+
+  -- Cache chaos characters
+  local chaos_str = config.get_chaos_chars()
+  local chaos_tbl = vim.fn.split(chaos_str, "\\zs")
+  local function random_chaos()
+    return chaos_tbl[math.random(1, #chaos_tbl)]
+  end
+
+  local smoothed = 0.0
+  local ns_id = animation.ns_id
+  local drops = {}
+
+  -- Stop any existing movement timer
+  if state.movement_timer then
+    state.movement_timer:stop()
+    state.movement_timer:close()
+    state.movement_timer = nil
+  end
+
+  state.movement_timer = vim.uv.new_timer()
+  state.movement_timer:start(80, 80, vim.schedule_wrap(function()
+    if not state.active or not buf or not vim.api.nvim_buf_is_valid(buf) then
+      if state.movement_timer then
+        state.movement_timer:stop()
+        state.movement_timer:close()
+        state.movement_timer = nil
+      end
+      return
+    end
+
+    -- Read audio level with 10x gain, clamped to 0-1
+    local raw = math.min(audio.get_level() * 10, 1.0)
+    smoothed = smoothed + (raw - smoothed) * 0.4
+
+    -- Spawn new drops based on audio level
+    local count = math.floor(smoothed * 8)
+    for _ = 1, count do
+      if #drops < 150 then
+        table.insert(drops, {
+          col = math.random(0, w - 1),
+          row = -1,
+          speed = 0.8 + math.random() * 0.4,
+          char = random_chaos(),
+        })
+      end
+    end
+
+    -- Move drops and remove those off-screen
+    local active_drops = {}
+    for _, drop in ipairs(drops) do
+      drop.row = drop.row + drop.speed
+      if drop.row < h then
+        table.insert(active_drops, drop)
+      end
+    end
+    drops = active_drops
+
+    -- Clear previous overlays
+    pcall(vim.api.nvim_buf_clear_namespace, buf, ns_id, 0, -1)
+
+    -- Skip rendering when silent and no drops
+    if smoothed < 0.02 and #drops == 0 then return end
+
+    -- Build a grid of drop characters
+    local grid = {}
+    for _, drop in ipairs(drops) do
+      local r = math.floor(drop.row)
+      if r >= 0 and r < h then
+        -- Skip drops inside art region
+        local in_art = (r >= art_top and r <= art_bottom and drop.col >= art_left and drop.col <= art_right)
+        if not in_art then
+          if not grid[r] then grid[r] = {} end
+          grid[r][drop.col] = drop.char
+        end
+      end
+    end
+
+    -- Render overlays row by row
+    for row = 0, h - 1 do
+      local in_art_rows = (row >= art_top and row <= art_bottom)
+      local art_row_idx = row - art_top + 1
+      local has_drops = grid[row] ~= nil
+
+      if in_art_rows or has_drops then
+        local overlay_chars = {}
+        local has_content = false
+
+        for col = 0, w - 1 do
+          local in_art_region = in_art_rows and col >= art_left and col <= art_right
+
+          if in_art_region then
+            -- Preserve art character
+            local line_left = art_left_pads[art_row_idx]
+            local local_col = col - line_left
+            local chars = art_chars[art_row_idx]
+            if local_col >= 0 and chars and local_col < #chars then
+              local ch = chars[local_col + 1]
+              if ch then
+                table.insert(overlay_chars, ch)
+              else
+                table.insert(overlay_chars, " ")
+              end
+            else
+              table.insert(overlay_chars, " ")
+            end
+          elseif has_drops and grid[row][col] then
+            table.insert(overlay_chars, grid[row][col])
+            has_content = true
+          else
+            table.insert(overlay_chars, " ")
+          end
+        end
+
+        if has_content or in_art_rows then
+          local overlay_text = table.concat(overlay_chars)
+          pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, row, 0, {
+            virt_text = { { overlay_text, "Normal" } },
+            virt_text_pos = "overlay",
+            hl_mode = "combine",
+          })
+        end
+      end
+    end
+  end))
+end
+
+-- Start shatter (audio-reactive exploding/reassembling art) after animation completes
+local function start_shatter(buf, art_lines, w, h)
+  -- Auto-start audio if not already running
+  if not audio.is_running() then
+    if not audio.start() then
+      return
+    end
+  end
+
+  local art_height = #art_lines
+  local top_pad = math.max(0, math.floor((h - art_height) / 2))
+
+  -- Build particles from non-space art chars at their centered buffer positions
+  local particles = {}
+  local center_x = w / 2
+  local center_y = top_pad + art_height / 2
+
+  for i, line in ipairs(art_lines) do
+    local chars = vim.fn.split(line, "\\zs")
+    local lw = vim.fn.strdisplaywidth(line)
+    local left_pad = math.max(0, math.floor((w - lw) / 2))
+    for j, ch in ipairs(chars) do
+      if ch ~= " " then
+        local px = left_pad + j - 1
+        local py = top_pad + i - 1
+        table.insert(particles, {
+          char = ch,
+          home_x = px,
+          home_y = py,
+          x = px,
+          y = py,
+          vx = 0,
+          vy = 0,
+        })
+      end
+    end
+  end
+
+  local smoothed = 0.0
+  local prev_smoothed = 0.0
+  local ns_id = animation.ns_id
+
+  -- Stop any existing movement timer
+  if state.movement_timer then
+    state.movement_timer:stop()
+    state.movement_timer:close()
+    state.movement_timer = nil
+  end
+
+  state.movement_timer = vim.uv.new_timer()
+  state.movement_timer:start(80, 80, vim.schedule_wrap(function()
+    if not state.active or not buf or not vim.api.nvim_buf_is_valid(buf) then
+      if state.movement_timer then
+        state.movement_timer:stop()
+        state.movement_timer:close()
+        state.movement_timer = nil
+      end
+      return
+    end
+
+    -- Read audio level with 10x gain, clamped to 0-1
+    local raw = math.min(audio.get_level() * 10, 1.0)
+    prev_smoothed = smoothed
+    smoothed = smoothed + (raw - smoothed) * 0.4
+
+    -- Explode on audio spike
+    local delta = smoothed - prev_smoothed
+    if delta > 0.1 then
+      for _, p in ipairs(particles) do
+        local angle = math.atan2(p.home_y - center_y, p.home_x - center_x)
+        local speed = smoothed * 2.0
+        p.vx = p.vx + math.cos(angle) * speed
+        p.vy = p.vy + math.sin(angle) * speed
+      end
+    end
+
+    -- Physics: spring back to home position
+    local spring = (smoothed < 0.05) and 0.25 or 0.15
+    for _, p in ipairs(particles) do
+      p.x = p.x + p.vx
+      p.y = p.y + p.vy
+      local fx = (p.home_x - p.x) * spring
+      local fy = (p.home_y - p.y) * spring
+      p.vx = p.vx * 0.85 + fx
+      p.vy = p.vy * 0.85 + fy
+    end
+
+    -- Clear previous overlays
+    pcall(vim.api.nvim_buf_clear_namespace, buf, ns_id, 0, -1)
+
+    -- Build grid from particles
+    local grid = {}
+    for _, p in ipairs(particles) do
+      local px = math.floor(p.x)
+      local py = math.floor(p.y)
+      if px >= 0 and px < w and py >= 0 and py < h then
+        if not grid[py] then grid[py] = {} end
+        grid[py][px] = p.char
+      end
+    end
+
+    -- Render overlays
+    for row = 0, h - 1 do
+      if grid[row] then
+        local overlay_chars = {}
+        local has_content = false
+        for col = 0, w - 1 do
+          if grid[row][col] then
+            table.insert(overlay_chars, grid[row][col])
+            has_content = true
+          else
+            table.insert(overlay_chars, " ")
+          end
+        end
+        if has_content then
+          local overlay_text = table.concat(overlay_chars)
+          pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, row, 0, {
+            virt_text = { { overlay_text, "Normal" } },
+            virt_text_pos = "overlay",
+            hl_mode = "combine",
+          })
+        end
+      end
+    end
+  end))
+end
+
+-- Start fireworks (audio-reactive burst explosions around art) after animation completes
+local function start_fireworks(buf, art_lines, w, h)
+  -- Auto-start audio if not already running
+  if not audio.is_running() then
+    if not audio.start() then
+      return
+    end
+  end
+
+  local art_height = #art_lines
+  local top_pad = math.max(0, math.floor((h - art_height) / 2))
+
+  -- Precompute art structure for reproduction
+  local art_chars = {}
+  local art_widths = {}
+  local art_left_pads = {}
+  for i, line in ipairs(art_lines) do
+    art_chars[i] = vim.fn.split(line, "\\zs")
+    local lw = vim.fn.strdisplaywidth(line)
+    art_widths[i] = lw
+    art_left_pads[i] = math.max(0, math.floor((w - lw) / 2))
+  end
+
+  -- Art bounding box in buffer coordinates (0-indexed)
+  local art_top = top_pad
+  local art_bottom = top_pad + art_height - 1
+  local max_art_width = 0
+  for _, lw in ipairs(art_widths) do
+    if lw > max_art_width then max_art_width = lw end
+  end
+  local art_left = math.max(0, math.floor((w - max_art_width) / 2))
+  local art_right = art_left + max_art_width - 1
+
+  -- Cache chaos characters
+  local chaos_str = config.get_chaos_chars()
+  local chaos_tbl = vim.fn.split(chaos_str, "\\zs")
+  local function random_chaos()
+    return chaos_tbl[math.random(1, #chaos_tbl)]
+  end
+
+  local smoothed = 0.0
+  local prev_smoothed = 0.0
+  local ns_id = animation.ns_id
+  local bursts = {}
+  local spawn_cooldown = 0
+
+  -- Stop any existing movement timer
+  if state.movement_timer then
+    state.movement_timer:stop()
+    state.movement_timer:close()
+    state.movement_timer = nil
+  end
+
+  state.movement_timer = vim.uv.new_timer()
+  state.movement_timer:start(80, 80, vim.schedule_wrap(function()
+    if not state.active or not buf or not vim.api.nvim_buf_is_valid(buf) then
+      if state.movement_timer then
+        state.movement_timer:stop()
+        state.movement_timer:close()
+        state.movement_timer = nil
+      end
+      return
+    end
+
+    -- Read audio level with 10x gain, clamped to 0-1
+    local raw = math.min(audio.get_level() * 10, 1.0)
+    prev_smoothed = smoothed
+    smoothed = smoothed + (raw - smoothed) * 0.4
+
+    -- Spawn burst on audio spike
+    if spawn_cooldown > 0 then
+      spawn_cooldown = spawn_cooldown - 1
+    end
+    local delta = smoothed - prev_smoothed
+    if smoothed > 0.2 and delta > 0.08 and spawn_cooldown == 0 and #bursts < 5 then
+      -- Random position 5-15 chars from art edge
+      local offset = math.random(5, 15)
+      local side = math.random(1, 4)
+      local cx, cy
+      if side == 1 then -- top
+        cx = math.random(art_left, art_right)
+        cy = art_top - offset
+      elseif side == 2 then -- bottom
+        cx = math.random(art_left, art_right)
+        cy = art_bottom + offset
+      elseif side == 3 then -- left
+        cx = art_left - offset
+        cy = math.random(art_top, art_bottom)
+      else -- right
+        cx = art_right + offset
+        cy = math.random(art_top, art_bottom)
+      end
+
+      local burst_particles = {}
+      local num = math.random(15, 25)
+      for _ = 1, num do
+        local angle = math.random() * math.pi * 2
+        local speed = 0.5 + math.random() * 1.5
+        table.insert(burst_particles, {
+          dx = 0,
+          dy = 0,
+          vx = math.cos(angle) * speed,
+          vy = math.sin(angle) * speed,
+          char = random_chaos(),
+          alpha = 1.0,
+        })
+      end
+      table.insert(bursts, { cx = cx, cy = cy, particles = burst_particles })
+      spawn_cooldown = 4
+    end
+
+    -- Move burst particles and decay
+    local active_bursts = {}
+    for _, burst in ipairs(bursts) do
+      local alive = {}
+      for _, p in ipairs(burst.particles) do
+        p.dx = p.dx + p.vx
+        p.dy = p.dy + p.vy
+        p.alpha = p.alpha * 0.88
+        if p.alpha >= 0.1 then
+          table.insert(alive, p)
+        end
+      end
+      if #alive > 0 then
+        burst.particles = alive
+        table.insert(active_bursts, burst)
+      end
+    end
+    bursts = active_bursts
+
+    -- Clear previous overlays
+    pcall(vim.api.nvim_buf_clear_namespace, buf, ns_id, 0, -1)
+
+    -- Skip rendering when silent and no bursts
+    if smoothed < 0.02 and #bursts == 0 then return end
+
+    -- Build grid from burst particles
+    local grid = {}
+    for _, burst in ipairs(bursts) do
+      for _, p in ipairs(burst.particles) do
+        if math.random() < p.alpha then
+          local px = math.floor(burst.cx + p.dx)
+          local py = math.floor(burst.cy + p.dy)
+          if px >= 0 and px < w and py >= 0 and py < h then
+            -- Skip art region
+            local in_art = (py >= art_top and py <= art_bottom and px >= art_left and px <= art_right)
+            if not in_art then
+              if not grid[py] then grid[py] = {} end
+              grid[py][px] = p.char
+            end
+          end
+        end
+      end
+    end
+
+    -- Render overlays row by row
+    for row = 0, h - 1 do
+      local in_art_rows = (row >= art_top and row <= art_bottom)
+      local art_row_idx = row - art_top + 1
+      local has_burst_chars = grid[row] ~= nil
+
+      if in_art_rows or has_burst_chars then
+        local overlay_chars = {}
+        local has_content = false
+
+        for col = 0, w - 1 do
+          local in_art_region = in_art_rows and col >= art_left and col <= art_right
+
+          if in_art_region then
+            -- Preserve art character
+            local line_left = art_left_pads[art_row_idx]
+            local local_col = col - line_left
+            local chars = art_chars[art_row_idx]
+            if local_col >= 0 and chars and local_col < #chars then
+              local ch = chars[local_col + 1]
+              if ch then
+                table.insert(overlay_chars, ch)
+              else
+                table.insert(overlay_chars, " ")
+              end
+            else
+              table.insert(overlay_chars, " ")
+            end
+          elseif has_burst_chars and grid[row][col] then
+            table.insert(overlay_chars, grid[row][col])
+            has_content = true
+          else
+            table.insert(overlay_chars, " ")
+          end
+        end
+
+        if has_content or in_art_rows then
+          local overlay_text = table.concat(overlay_chars)
+          pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, row, 0, {
+            virt_text = { { overlay_text, "Normal" } },
+            virt_text_pos = "overlay",
+            hl_mode = "combine",
+          })
+        end
+      end
+    end
+  end))
+end
+
+-- Start heartbeat (audio-reactive pulsing aura border around art) after animation completes
+local function start_heartbeat(buf, art_lines, w, h)
+  -- Auto-start audio if not already running
+  if not audio.is_running() then
+    if not audio.start() then
+      return
+    end
+  end
+
+  local art_height = #art_lines
+  local top_pad = math.max(0, math.floor((h - art_height) / 2))
+
+  -- Precompute art structure for reproduction
+  local art_chars = {}
+  local art_widths = {}
+  local art_left_pads = {}
+  for i, line in ipairs(art_lines) do
+    art_chars[i] = vim.fn.split(line, "\\zs")
+    local lw = vim.fn.strdisplaywidth(line)
+    art_widths[i] = lw
+    art_left_pads[i] = math.max(0, math.floor((w - lw) / 2))
+  end
+
+  -- Art bounding box in buffer coordinates (0-indexed)
+  local art_top = top_pad
+  local art_bottom = top_pad + art_height - 1
+  local max_art_width = 0
+  for _, lw in ipairs(art_widths) do
+    if lw > max_art_width then max_art_width = lw end
+  end
+  local art_left = math.max(0, math.floor((w - max_art_width) / 2))
+  local art_right = art_left + max_art_width - 1
+
+  -- Cache chaos characters
+  local chaos_str = config.get_chaos_chars()
+  local chaos_tbl = vim.fn.split(chaos_str, "\\zs")
+  local function random_chaos()
+    return chaos_tbl[math.random(1, #chaos_tbl)]
+  end
+
+  local smoothed = 0.0
+  local prev_smoothed = 0.0
+  local ns_id = animation.ns_id
+  local aura_intensity = 0.0
+  local beat_cooldown = 0
+
+  -- Stop any existing movement timer
+  if state.movement_timer then
+    state.movement_timer:stop()
+    state.movement_timer:close()
+    state.movement_timer = nil
+  end
+
+  state.movement_timer = vim.uv.new_timer()
+  state.movement_timer:start(80, 80, vim.schedule_wrap(function()
+    if not state.active or not buf or not vim.api.nvim_buf_is_valid(buf) then
+      if state.movement_timer then
+        state.movement_timer:stop()
+        state.movement_timer:close()
+        state.movement_timer = nil
+      end
+      return
+    end
+
+    -- Read audio level with 10x gain, clamped to 0-1
+    local raw = math.min(audio.get_level() * 10, 1.0)
+    prev_smoothed = smoothed
+    smoothed = smoothed + (raw - smoothed) * 0.4
+
+    -- Beat detection
+    if beat_cooldown > 0 then
+      beat_cooldown = beat_cooldown - 1
+    end
+    local delta = smoothed - prev_smoothed
+    if smoothed > 0.25 and delta > 0.12 and beat_cooldown == 0 then
+      aura_intensity = math.min(smoothed * 1.5, 1.0)
+      beat_cooldown = 8
+    end
+
+    -- Decay aura
+    aura_intensity = aura_intensity * 0.85
+
+    -- Clear previous overlays
+    pcall(vim.api.nvim_buf_clear_namespace, buf, ns_id, 0, -1)
+
+    -- Skip rendering when aura is negligible
+    if aura_intensity < 0.02 then return end
+
+    local thickness = math.ceil(aura_intensity * 4)
+
+    -- Render aura around art
+    for row = 0, h - 1 do
+      local in_art_rows = (row >= art_top and row <= art_bottom)
+      local art_row_idx = row - art_top + 1
+
+      -- Chebyshev distance to art bounding box
+      local dy = 0
+      if row < art_top then
+        dy = art_top - row
+      elseif row > art_bottom then
+        dy = row - art_bottom
+      end
+
+      local overlay_chars = {}
+      local has_content = false
+
+      for col = 0, w - 1 do
+        local dx = 0
+        if col < art_left then
+          dx = art_left - col
+        elseif col > art_right then
+          dx = col - art_right
+        end
+
+        local distance = math.max(dx, dy)
+        local in_art_region = in_art_rows and col >= art_left and col <= art_right
+
+        if in_art_region then
+          -- Preserve art character
+          local line_left = art_left_pads[art_row_idx]
+          local local_col = col - line_left
+          local chars = art_chars[art_row_idx]
+          if local_col >= 0 and chars and local_col < #chars then
+            local ch = chars[local_col + 1]
+            if ch then
+              table.insert(overlay_chars, ch)
+            else
+              table.insert(overlay_chars, " ")
+            end
+          else
+            table.insert(overlay_chars, " ")
+          end
+        elseif distance >= 1 and distance <= thickness then
+          -- Aura zone: probability falls off with distance
+          local probability = aura_intensity * (1 - (distance - 1) / thickness)
+          if probability > 0 and math.random() < probability then
+            table.insert(overlay_chars, random_chaos())
+            has_content = true
+          else
+            table.insert(overlay_chars, " ")
+          end
+        else
+          table.insert(overlay_chars, " ")
+        end
+      end
+
+      if has_content or in_art_rows then
+        local overlay_text = table.concat(overlay_chars)
+        pcall(vim.api.nvim_buf_set_extmark, buf, ns_id, row, 0, {
+          virt_text = { { overlay_text, "Normal" } },
+          virt_text_pos = "overlay",
+          hl_mode = "combine",
+        })
+      end
+    end
+  end))
 end
 
 -- Trigger the screensaver
@@ -374,7 +1311,7 @@ function M.trigger()
     local zoomed = zoom_art(art_lines)
     lines, top_pad, art_height = build_centered_buffer(zoomed, width, height)
   else
-    -- static, bounce, marquee: start with centered art
+    -- static, bounce, marquee, pulse, waves, rain, shatter, fireworks, heartbeat: start with centered art
     lines, top_pad, art_height = build_centered_buffer(art_lines, width, height)
   end
 
@@ -421,6 +1358,48 @@ function M.trigger()
         start_marquee(state.buf, art_lines, width, height)
       end
     end
+  elseif display_mode == "pulse" then
+    config.options.animation.loop = false
+    on_complete = function()
+      if state.active and state.buf and vim.api.nvim_buf_is_valid(state.buf) then
+        start_pulse(state.buf, art_lines, width, height)
+      end
+    end
+  elseif display_mode == "waves" then
+    config.options.animation.loop = false
+    on_complete = function()
+      if state.active and state.buf and vim.api.nvim_buf_is_valid(state.buf) then
+        start_waves(state.buf, art_lines, width, height)
+      end
+    end
+  elseif display_mode == "rain" then
+    config.options.animation.loop = false
+    on_complete = function()
+      if state.active and state.buf and vim.api.nvim_buf_is_valid(state.buf) then
+        start_rain(state.buf, art_lines, width, height)
+      end
+    end
+  elseif display_mode == "shatter" then
+    config.options.animation.loop = false
+    on_complete = function()
+      if state.active and state.buf and vim.api.nvim_buf_is_valid(state.buf) then
+        start_shatter(state.buf, art_lines, width, height)
+      end
+    end
+  elseif display_mode == "fireworks" then
+    config.options.animation.loop = false
+    on_complete = function()
+      if state.active and state.buf and vim.api.nvim_buf_is_valid(state.buf) then
+        start_fireworks(state.buf, art_lines, width, height)
+      end
+    end
+  elseif display_mode == "heartbeat" then
+    config.options.animation.loop = false
+    on_complete = function()
+      if state.active and state.buf and vim.api.nvim_buf_is_valid(state.buf) then
+        start_heartbeat(state.buf, art_lines, width, height)
+      end
+    end
   else
     -- static, tile, zoom: loop the animation
     config.options.animation.loop = true
@@ -433,6 +1412,30 @@ function M.trigger()
       animation.start(state.buf, total_anim_lines, "Normal", on_complete)
     end
   end, 10)
+
+  -- Start audio-reactive mode if enabled
+  if ss_opts.audio_reactive then
+    -- Save originals before modifying
+    state.original_loop_delay = config.options.animation.loop_delay
+    state.original_ambient_interval = config.options.animation.ambient_interval
+
+    if audio.start() then
+      -- For looping modes (static/tile/zoom): modulate loop_delay based on audio level
+      if display_mode == "static" or display_mode == "tile" or display_mode == "zoom" then
+        state.audio_modulator = vim.uv.new_timer()
+        state.audio_modulator:start(200, 200, vim.schedule_wrap(function()
+          if not state.active or not audio.is_running() then
+            return
+          end
+          local level = audio.get_level()
+          -- Map level to loop_delay: 2000ms (silence) → 200ms (loud)
+          local base = state.original_loop_delay or 2000
+          local min_delay = 200
+          config.options.animation.loop_delay = math.floor(base - (base - min_delay) * level)
+        end))
+      end
+    end
+  end
 
   -- Setup dismiss keybindings
   setup_dismiss_keys(state.buf)
@@ -458,6 +1461,24 @@ function M.dismiss()
   end
 
   animation.stop()
+
+  -- Stop audio sampling and modulator
+  audio.stop()
+  if state.audio_modulator then
+    state.audio_modulator:stop()
+    state.audio_modulator:close()
+    state.audio_modulator = nil
+  end
+
+  -- Restore audio-modified settings
+  if state.original_loop_delay ~= nil then
+    config.options.animation.loop_delay = state.original_loop_delay
+    state.original_loop_delay = nil
+  end
+  if state.original_ambient_interval ~= nil then
+    config.options.animation.ambient_interval = state.original_ambient_interval
+    state.original_ambient_interval = nil
+  end
 
   -- Stop movement timer
   if state.movement_timer then


### PR DESCRIPTION
## Summary
- Add 4 new audio-reactive screensaver display modes: **rain** (falling characters), **shatter** (exploding/reassembling art), **fireworks** (burst explosions around art), **heartbeat** (pulsing aura border)
- Add `audio.lua` module for microphone input via sox (`rec` command)
- Add `audio_reactive` toggle to `:AsciiSettings` screensaver submenu
- Include audio modes in random pool when sox is available
- Add sox health check in `:checkhealth`

## Test plan
- [ ] `:AsciiSettings` → `V` → cycle display modes with `[m]` — all 4 new modes appear
- [ ] `:AsciiSettings` → `V` → `[a]` toggles audio reactive ON/OFF
- [ ] `:AsciiScreensaver` with each new mode: rain, shatter, fireworks, heartbeat
- [ ] Without sox installed: modes degrade gracefully (clean art, no crash)
- [ ] Random mode includes audio modes when sox available
- [ ] `:checkhealth ascii-animation` reports sox status

🤖 Generated with [Claude Code](https://claude.com/claude-code)