### PR TITLE
feat: add custom effect API

### DIFF
--- a/lua/ascii-animation/commands.lua
+++ b/lua/ascii-animation/commands.lua
@@ -1290,7 +1290,7 @@ local update_preview_buffer
 
 -- Cycle through effect options
 local function cycle_effect(delta)
-  local effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "scramble", "rain", "spiral", "explode", "implode", "glitch", "random" }
+  local effects = vim.list_extend(vim.deepcopy(animation.effect_names), { "random" })
   local current = config.options.animation.effect
   local idx = 1
   for i, e in ipairs(effects) do
@@ -2983,12 +2983,12 @@ function M.register_commands()
     if animation.set_effect(name) then
       vim.notify("Effect set to: " .. name, vim.log.levels.INFO)
     else
-      vim.notify("Invalid effect. Valid: chaos, typewriter, diagonal, lines, matrix, wave, fade, scramble, rain, spiral, explode, implode, glitch, random", vim.log.levels.WARN)
+      vim.notify("Invalid effect. Valid: " .. table.concat(animation.effect_names, ", ") .. ", random", vim.log.levels.WARN)
     end
   end, {
     nargs = "?",
     complete = function(arg_lead)
-      local valid_effects = { "chaos", "typewriter", "diagonal", "lines", "matrix", "wave", "fade", "scramble", "rain", "spiral", "explode", "implode", "glitch", "random" }
+      local valid_effects = vim.list_extend(vim.deepcopy(animation.effect_names), { "random" })
       local matches = {}
       for _, name in ipairs(valid_effects) do
         if name:find(arg_lead, 1, true) then

--- a/lua/ascii-animation/init.lua
+++ b/lua/ascii-animation/init.lua
@@ -345,6 +345,11 @@ function M.set_effect(name)
   return animation.set_effect(name)
 end
 
+-- Register a custom animation effect
+function M.register_effect(name, def)
+  return animation.register_effect(name, def)
+end
+
 -- Apply a named theme preset
 function M.apply_preset(name)
   return config.apply_preset(name)


### PR DESCRIPTION
## Summary
- Add `register_effect()` public API so users can define custom animation effects without modifying plugin source
- Custom effects integrate into `:AsciiEffect` tab completion, `:AsciiSettings` cycling, and random selection
- Transform functions are pcall-wrapped for safety — broken effects fall back gracefully
- Replace hardcoded effect lists in commands.lua with dynamic `animation.effect_names`

Closes #68

## Test plan
- [ ] Register a custom effect via `ascii.register_effect("name", { transform = ... })` and verify it works
- [ ] Verify custom effects appear in `:AsciiEffect` tab completion
- [ ] Verify custom effects cycle in `:AsciiSettings`
- [ ] Test a broken transform (error inside) falls back to original line
- [ ] Test custom `get_delay` overrides timing
- [ ] `luac -p` passes on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)